### PR TITLE
Add method to track attribution from an incoming NSUserActivity

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -72,7 +72,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
         
-        ButtonMerchant.trackIncomingActivity(userActivity)
+        ButtonMerchant.trackIncomingUserActivity(userActivity)
         
         return true
     }

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -72,9 +72,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
         
-        if let url = userActivity.webpageURL {
-            ButtonMerchant.trackIncomingURL(url)
-        }
+        ButtonMerchant.trackIncomingActivity(userActivity)
         
         return true
     }

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -93,6 +93,26 @@ final public class ButtonMerchant: NSObject {
     }
     
     /**
+     Checks the URL in the passed NSUserActivity for a Button attribution and if present stores the token.
+     
+     - Attention:
+     To correctly attribute customers, you must call this method with every
+     incoming `userActivity` from the following `UIApplicationDelegate` method:
+     
+     - `application(_:userActivity:restorationHandler:)`
+     
+     - Parameters:
+     - activity: A NSUserActivity with which your app has been continued.
+     
+     */
+    public static func trackIncomingActivity(_ activity: NSUserActivity) {
+        guard let url = activity.webpageURL else {
+            return
+        }
+        core.trackIncomingURL(url)
+    }
+    
+    /**
      Checks to see if the user visited a url prior to installing your app.
 
      If a url is found, your completion handler will be called with the url and you are responsible

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -102,11 +102,11 @@ final public class ButtonMerchant: NSObject {
      - `application(_:userActivity:restorationHandler:)`
      
      - Parameters:
-     - activity: A NSUserActivity with which your app has been continued.
+     - userActivity: A NSUserActivity with which your app has been continued.
      
      */
-    public static func trackIncomingActivity(_ activity: NSUserActivity) {
-        guard let url = activity.webpageURL else {
+    public static func trackIncomingUserActivity(_ userActivity: NSUserActivity) {
+        guard let url = userActivity.webpageURL else {
             return
         }
         core.trackIncomingURL(url)

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -77,7 +77,7 @@ class ButtonMerchantTests: XCTestCase {
         XCTAssertEqual(actualUrl, expectedUrl)
     }
     
-    func testTrackIncomingActivityInvokesCore() {
+    func testTrackIncomingUserActivityInvokesCore() {
         // Arrange
         let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
                                 client: TestClient(session: TestURLSession(),
@@ -85,12 +85,12 @@ class ButtonMerchantTests: XCTestCase {
                                 system: TestSystem(),
                                 notificationCenter: TestNotificationCenter())
         let expectedUrl = URL(string: "https://usebutton.com")!
-        let activity = NSUserActivity(activityType: "com.usebutton.web_activity")
-        activity.webpageURL = expectedUrl
+        let userActivity = NSUserActivity(activityType: "com.usebutton.web_activity")
+        userActivity.webpageURL = expectedUrl
         
         // Act
         ButtonMerchant._core = testCore
-        ButtonMerchant.trackIncomingActivity(activity)
+        ButtonMerchant.trackIncomingUserActivity(userActivity)
         let actualUrl = testCore.testUrl
         
         // Assert

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -76,6 +76,26 @@ class ButtonMerchantTests: XCTestCase {
         // Assert
         XCTAssertEqual(actualUrl, expectedUrl)
     }
+    
+    func testTrackIncomingActivityInvokesCore() {
+        // Arrange
+        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                                client: TestClient(session: TestURLSession(),
+                                                   userAgent: TestUserAgent(system: TestSystem())),
+                                system: TestSystem(),
+                                notificationCenter: TestNotificationCenter())
+        let expectedUrl = URL(string: "https://usebutton.com")!
+        let activity = NSUserActivity(activityType: "com.usebutton.web_activity")
+        activity.webpageURL = expectedUrl
+        
+        // Act
+        ButtonMerchant._core = testCore
+        ButtonMerchant.trackIncomingActivity(activity)
+        let actualUrl = testCore.testUrl
+        
+        // Assert
+        XCTAssertEqual(actualUrl, expectedUrl)
+    }
 
     func testAccessingAttributionToken() {
         // Arrange


### PR DESCRIPTION
### Goals :dart:
Provide one-line ability to track URLs from incoming NSUserActivity objects.