### PR TITLE
Add Application ID to all API requests

### DIFF
--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -45,6 +45,7 @@ final public class ButtonMerchant: NSObject {
         // This should never be set directly
         set { }
     }
+    private static var applicationIdRegex = "^app-[0-9a-zA-Z-]+$"
     
     /**
      The last tracked `attributionToken` from an inbound Button attributed URL.
@@ -71,7 +72,9 @@ final public class ButtonMerchant: NSObject {
 
      */
     @objc public static func configure(applicationId: String) {
-        core.applicationId = applicationId
+        if applicationId.range(of: applicationIdRegex, options: .regularExpression) != nil {
+            core.applicationId = applicationId
+        }
     }
     
     /**

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -45,7 +45,7 @@ final public class ButtonMerchant: NSObject {
         // This should never be set directly
         set { }
     }
-    private static var applicationIdRegex = "^app-[0-9a-zA-Z-]+$"
+    private static let applicationIdRegex = "^app-[0-9a-zA-Z-]+$"
     
     /**
      The last tracked `attributionToken` from an inbound Button attributed URL.
@@ -72,9 +72,14 @@ final public class ButtonMerchant: NSObject {
 
      */
     @objc public static func configure(applicationId: String) {
-        if applicationId.range(of: applicationIdRegex, options: .regularExpression) != nil {
-            core.applicationId = applicationId
+        guard applicationId.range(of: applicationIdRegex, options: .regularExpression) != nil else {
+            print("""
+                Button App ID '\(applicationId)' is not valid.
+                You can find your App ID in the dashboard by logging in at https://app.usebutton.com/
+                """)
+            return
         }
+        core.applicationId = applicationId
     }
     
     /**

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -47,7 +47,11 @@ internal protocol CoreType {
  */
 final internal class Core: CoreType {
 
-    var applicationId: String?
+    var applicationId: String? {
+        didSet {
+            client.applicationId = self.applicationId
+        }
+    }
     var buttonDefaults: ButtonDefaultsType
     var client: ClientType
     var system: SystemType

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -143,4 +143,11 @@ class IntegrationTests: XCTestCase {
         
         XCTAssertNil(ButtonMerchant.attributionToken)
     }
+
+    func testConfigurePassesApplicationIdThroughToClient() {
+        let expectedApplicationId = "app-abc123"
+        ButtonMerchant.configure(applicationId: expectedApplicationId)
+
+        XCTAssertEqual(ButtonMerchant._core?.client.applicationId, expectedApplicationId)
+    }
 }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -36,7 +36,7 @@ class ButtonMerchantTests: XCTestCase {
         XCTAssertEqual(ButtonMerchantVersionNumber, 1)
     }
 
-    func testConfigureApplicationId() {
+    func testConfigureApplicationIdSetsApplicationIdOnCore() {
         // Arrange
         let applicationId = "app-test"
         let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
@@ -51,6 +51,23 @@ class ButtonMerchantTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(testCore.applicationId, applicationId)
+    }
+
+    func testConfigureApplicationIdDoesNotSetApplicationIdOnCore() {
+        // Arrange
+        let applicationId = "invalid-app-id"
+        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                                client: TestClient(session: TestURLSession(),
+                                                   userAgent: TestUserAgent(system: TestSystem())),
+                                system: TestSystem(),
+                                notificationCenter: TestNotificationCenter())
+
+        // Act
+        ButtonMerchant._core = testCore
+        ButtonMerchant.configure(applicationId: applicationId)
+
+        // Assert
+        XCTAssertNil(testCore.applicationId)
     }
 
     func testCreateCoreCreatesCoreWhenCoreSetToNil() {

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -53,7 +53,7 @@ class ButtonMerchantTests: XCTestCase {
         XCTAssertEqual(testCore.applicationId, applicationId)
     }
 
-    func testConfigureApplicationIdDoesNotSetApplicationIdOnCore() {
+    func testConfigureApplicationIdDoesNotSetInvalidApplicationIdOnCore() {
         // Arrange
         let applicationId = "invalid-app-id"
         let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -164,12 +164,26 @@ class ClientTests: XCTestCase {
         self.wait(for: [expectation], timeout: 2.0)
     }
 
+    func testFetchPostInstallURLDoesNothingWhenApplicationIdIsNotSet() {
+        // Arrange
+        let testURLSession = TestURLSession()
+        let client = Client(session: testURLSession, userAgent: TestUserAgent())
+
+        // Act
+        client.fetchPostInstallURL(parameters: ["blargh": "blergh"]) { _, _ in }
+
+        // Assert
+        XCTAssertFalse(testURLSession.didCallDataTaskWithRequest)
+        XCTAssertNil(testURLSession.lastDataTask)
+    }
+
     func testFetchPostInstallURLEnqueuesRequest() {
         // Arrange
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
+        client.applicationId = "app-abc123"
         let expectedParameters = ["blargh": "blergh"]
-        let expectedURL = URL(string: "https://api.usebutton.com/v1/web/deferred-deeplink")!
+        let expectedURL = URL(string: "https://app-abc123.mobileapi.usebutton.com/v1/web/deferred-deeplink")!
 
         // Act
         client.fetchPostInstallURL(parameters: expectedParameters) { _, _ in }
@@ -191,6 +205,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "fetch post install url success")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
+        client.applicationId = "app-abc123"
         let expectedURL = URL(string: "https://usebutton.com")!
         let expectedToken = "srctok-abc123"
         let responseDict: [String: Any] = ["object": ["action": expectedURL.absoluteString,
@@ -218,6 +233,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "fetch post install url fails bad response")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
+        client.applicationId = "app-abc123"
         let url = URL(string: "https://usebutton.com")!
         let responseDict = ["blargh": "blergh"]
         let data = try? JSONSerialization.data(withJSONObject: responseDict)
@@ -238,12 +254,26 @@ class ClientTests: XCTestCase {
         self.wait(for: [expectation], timeout: 2.0)
     }
 
+    func testTrackOrderThrowsError() {
+        // Arrange
+        let testURLSession = TestURLSession()
+        let client = Client(session: testURLSession, userAgent: TestUserAgent())
+
+        // Act
+        client.trackOrder(parameters: ["blargh": "blergh"]) { _ in }
+
+        // Assert
+        XCTAssertFalse(testURLSession.didCallDataTaskWithRequest)
+        XCTAssertNil(testURLSession.lastDataTask)
+    }
+
     func testTrackOrderEnqueuesRequest() {
         // Arrange
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
+        client.applicationId = "app-abc123"
         let expectedParameters = ["blargh": "blergh"]
-        let expectedURL = URL(string: "https://api.usebutton.com/v1/activity/order")!
+        let expectedURL = URL(string: "https://app-abc123.mobileapi.usebutton.com/v1/activity/order")!
         
         // Act
         client.trackOrder(parameters: expectedParameters) { _ in }
@@ -265,6 +295,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "track order success")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
+        client.applicationId = "app-abc123"
         let url = URL(string: "https://api.usebutton.com/v1/activity/order")!
         
         // Act
@@ -286,6 +317,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "track order fails")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
+        client.applicationId = "app-abc123"
         let url = URL(string: "https://api.usebutton.com/v1/activity/order")!
         let expectedError = TestError.known
         

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -34,7 +34,8 @@ class TestClient: ClientType {
 
     var session: URLSessionType
     var userAgent: UserAgentType
-
+    var applicationId: String?
+    
     var postInstallCompletion: ((URL?, String?) -> Void)?
     var trackOrderCompletion: ((Error?) -> Void)?
 


### PR DESCRIPTION
### Goals :dart:
Update our Merchant Library to use application-id based hostnames: 
Ex. `https://app-1234123412341234.mobile-api.usebutton.com`

### Implementation Details :construction:
* `ButtonMerchant.configure` now performs a validation step on the supplied `applicationId`
* `didSet` is implemented on `applicationId` in `Core` so that it can pass it through to the `Client`
* The `ClientType` protocol now includes an `applicationId` property
* API Requests are now within a `do/catch` block that log out to the console the error description for a missing app id.
*

### Testing Details :mag:
* Changes have been unit tested
* Integration test added that verifies calling `configure` on `ButtonMerchant` passes the value to `Core`
