### PR TITLE
Add Line Item model

### DIFF
--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -25,7 +25,7 @@
 import Foundation
 import CommonCrypto
 
-extension String {
+public extension String {
 
     var sha256: String {
         guard let stringData = self.data(using: .utf8) else {
@@ -41,7 +41,7 @@ extension String {
         return NSData(bytes: hash, length: digestLength)
     }
 
-    private  func hexStringFromData(input: NSData) -> String {
+    private func hexStringFromData(input: NSData) -> String {
         var bytes = [UInt8](repeating: 0, count: input.length)
         input.getBytes(&bytes, length: input.length)
 

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -28,7 +28,8 @@ import CommonCrypto
 /**
 Represents an order placed by the user to be tracked using `ButtonMerchant.trackOrder(order)`.
  */
-@objcMembers final public class Order: NSObject, Codable {
+@objcMembers
+final public class Order: NSObject, Codable {
 
     /**
      The order identifier (required).
@@ -113,7 +114,8 @@ Represents an order placed by the user to be tracked using `ButtonMerchant.track
     /**
      Represents a customer in the order.
      */
-    @objcMembers public class Customer: NSObject, Codable {
+    @objcMembers
+    @objc(Customer) final public class Customer: NSObject, Codable {
         
         /**
          The id for the transacting customer in your system (required).
@@ -156,7 +158,8 @@ Represents an order placed by the user to be tracked using `ButtonMerchant.track
     /**
      Represents a line item in the order.
      */
-    final public class LineItem: NSObject, Codable {
+    @objcMembers
+    @objc(LineItem) final public class LineItem: NSObject, Codable {
 
         /**
          The unique identifier for this line item,
@@ -171,35 +174,35 @@ Represents an order placed by the user to be tracked using `ButtonMerchant.track
         let total: Int64
 
         /**
-         The number of unique units represented by this line item.
+         The number of unique units represented by this line item (default is 1).
          */
-        let quantity: Int
+        public var quantity: Int
 
         /**
          Text describing the line item.
          */
-        let itemDescription: String?
+        public var itemDescription: String?
 
         /**
          The Stock Keeping Unit of the line item.
          */
-        let sku: String?
+        public var sku: String?
 
         /**
          The Universal Product Code of the line item.
          */
-        let upc: String?
+        public var upc: String?
 
         /**
          The category of the line item.
          An ordered list of strings, starting with the topmost (or most general) category.
          */
-        let category: [String]?
+        public var category: [String]?
 
         /**
          A key/value store for strings to specify additional information about a line item.
          */
-        let attributes: [String: String]?
+        public var attributes: [String: String]?
 
         /**
          An array of the line item details that comprise the order
@@ -209,24 +212,11 @@ Represents an order placed by the user to be tracked using `ButtonMerchant.track
                           This must be unique across all line-items within the order.
                           We suggest using the SKU or UPC of the product. (required)
             - total: The total price of all items bought in a particular line item. (required)
-            - quantity: The number of unique units represented by this line item. (required)
-            - itemDescription: Text describing the line item.
-            - sku: The Stock Keeping Unit of the line item.
-            - upc: The Universal Product Code of the line item.
-            - category: The category of the line item.
-            - attributes: A key/value store for strings to specify additional information about a line item.
          */
-        @objc public init(identifier: String, total: Int64, quantity: Int,
-                          itemDescription: String? = nil, sku: String? = nil, upc: String? = nil,
-                          category: [String]? = nil, attributes: [String: String]? = nil) {
+        @objc public init(identifier: String, total: Int64) {
             self.identifier = identifier
             self.total = total
-            self.quantity = quantity
-            self.itemDescription = itemDescription
-            self.sku = sku
-            self.upc = upc
-            self.category = category
-            self.attributes = attributes
+            self.quantity = 1
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -51,7 +51,7 @@ Represents an order placed by the user to be tracked using `ButtonMerchant.track
     public var currencyCode: String = "USD"
 
     /**
-     The customer-facing order id
+     The customer-facing order id.
      */
     public var customerOrderId: String?
 
@@ -67,13 +67,6 @@ Represents an order placed by the user to be tracked using `ButtonMerchant.track
     @available(*, deprecated)
     private(set) var amount: Int64 = 0
 
-    /**
-     Represents a line item in the order.
-     */
-    public class LineItem: NSObject, Codable {
-        
-    }
-    
     /**
      Initializes an order object with the passed parameters.
 
@@ -159,4 +152,93 @@ Represents an order placed by the user to be tracked using `ButtonMerchant.track
             case advertisingId = "advertising_id"
         }
     }
+
+    /**
+     Represents a line item in the order.
+     */
+    final public class LineItem: NSObject, Codable {
+
+        /**
+         The unique identifier for this line item,
+         within the scope of this order. (required).
+         */
+        let identifier: String
+
+        /**
+         The total price of all items bought in a particular line item (required).
+         (e.g. if 3 bananas were purchased for $3.00 each, total would be 900).
+         */
+        let total: Int64
+
+        /**
+         The number of unique units represented by this line item.
+         */
+        let quantity: Int
+
+        /**
+         Text describing the line item.
+         */
+        let itemDescription: String?
+
+        /**
+         The Stock Keeping Unit of the line item.
+         */
+        let sku: String?
+
+        /**
+         The Universal Product Code of the line item.
+         */
+        let upc: String?
+
+        /**
+         The category of the line item.
+         An ordered list of strings, starting with the topmost (or most general) category.
+         */
+        let category: [String]?
+
+        /**
+         A key/value store for strings to specify additional information about a line item.
+         */
+        let attributes: [String: String]?
+
+        /**
+         An array of the line item details that comprise the order
+
+         - Parameters:
+            - identifier: The unique identifier for this line item, within the scope of this order.
+                          This must be unique across all line-items within the order.
+                          We suggest using the SKU or UPC of the product. (required)
+            - total: The total price of all items bought in a particular line item. (required)
+            - quantity: The number of unique units represented by this line item. (required)
+            - itemDescription: Text describing the line item.
+            - sku: The Stock Keeping Unit of the line item.
+            - upc: The Universal Product Code of the line item.
+            - category: The category of the line item.
+            - attributes: A key/value store for strings to specify additional information about a line item.
+         */
+        @objc public init(identifier: String, total: Int64, quantity: Int,
+                          itemDescription: String? = nil, sku: String? = nil, upc: String? = nil,
+                          category: [String]? = nil, attributes: [String: String]? = nil) {
+            self.identifier = identifier
+            self.total = total
+            self.quantity = quantity
+            self.itemDescription = itemDescription
+            self.sku = sku
+            self.upc = upc
+            self.category = category
+            self.attributes = attributes
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case identifier
+            case total
+            case quantity
+            case itemDescription = "description"
+            case sku
+            case upc
+            case category
+            case attributes
+        }
+    }
+
 }

--- a/Tests/UnitTests/OrderTests.swift
+++ b/Tests/UnitTests/OrderTests.swift
@@ -31,7 +31,7 @@ class OrderTests: XCTestCase {
         // Arrange
         let id = "order-abc"
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
-        let lineItems = [Order.LineItem()]
+        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 400, quantity: 2)]
 
         // Act
         let order = Order(id: id,
@@ -52,7 +52,7 @@ class OrderTests: XCTestCase {
         let id = "order-abc"
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
         let currencyCode = "EUR"
-        let lineItems = [Order.LineItem()]
+        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 400, quantity: 2)]
         let customerOrderId = "123"
         let customer = Order.Customer()
         
@@ -168,6 +168,52 @@ class OrderTests: XCTestCase {
         customer.advertisingId = advertisingId
         
         XCTAssertEqual(customer.emailSha256, emailSha256)
+    }
+
+    func testLineItemInitialization_requiredPropertiesOnly() {
+        let identifier = "unique-id-123"
+        let total: Int64 = 4000
+        let quantity = 2
+
+        let lineItem = Order.LineItem(identifier: identifier, total: total, quantity: quantity)
+
+        XCTAssertEqual(lineItem.identifier, identifier)
+        XCTAssertEqual(lineItem.total, total)
+        XCTAssertEqual(lineItem.quantity, quantity)
+        XCTAssertNil(lineItem.itemDescription)
+        XCTAssertNil(lineItem.sku)
+        XCTAssertNil(lineItem.upc)
+        XCTAssertNil(lineItem.category)
+        XCTAssertNil(lineItem.attributes)
+    }
+
+    func testLineItemInitialization_allProperties() {
+        let identifier = "unique-id-123"
+        let total: Int64 = 4000
+        let quantity = 2
+        let itemDescription = "laptop"
+        let sku = "1234"
+        let upc = "0987654321"
+        let category = ["Electronics", "Computers"]
+        let attributes = ["Model": "MacBook Pro"]
+
+        let lineItem = Order.LineItem(identifier: identifier,
+                                       total: total,
+                                       quantity: quantity,
+                                       itemDescription: itemDescription,
+                                       sku: sku,
+                                       upc: upc,
+                                       category: category,
+                                       attributes: attributes)
+
+        XCTAssertEqual(lineItem.identifier, identifier)
+        XCTAssertEqual(lineItem.total, total)
+        XCTAssertEqual(lineItem.quantity, quantity)
+        XCTAssertEqual(lineItem.itemDescription, itemDescription)
+        XCTAssertEqual(lineItem.sku, sku)
+        XCTAssertEqual(lineItem.upc, upc)
+        XCTAssertEqual(lineItem.category, category)
+        XCTAssertEqual(lineItem.attributes, attributes)
     }
 
 }

--- a/Tests/UnitTests/OrderTests.swift
+++ b/Tests/UnitTests/OrderTests.swift
@@ -31,7 +31,7 @@ class OrderTests: XCTestCase {
         // Arrange
         let id = "order-abc"
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
-        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 400, quantity: 2)]
+        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 400)]
 
         // Act
         let order = Order(id: id,
@@ -52,7 +52,7 @@ class OrderTests: XCTestCase {
         let id = "order-abc"
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
         let currencyCode = "EUR"
-        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 400, quantity: 2)]
+        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 400)]
         let customerOrderId = "123"
         let customer = Order.Customer()
         
@@ -126,60 +126,71 @@ class OrderTests: XCTestCase {
     }
     
     func testCustomerInitialization_hashingEmail() {
+        // Arrange
         let id = "123"
         let email = "betty@usebutton.com"
         let emailSha256 = "c399e8d0e89e9f09aa14a36392e4cb0d058ab28b16247e80eab78ea5541a20d3"
         let advertisingId = "123"
-        
+
+        // Act
         let customer = Order.Customer()
         customer.id = id
         customer.setEmail(email)
         customer.advertisingId = advertisingId
 
+        // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertEqual(customer.emailSha256, emailSha256)
         XCTAssertEqual(customer.advertisingId, advertisingId)
     }
     
     func testCustomerInitialization_providingHashedEmail() {
+        // Arrange
         let id = "123"
         let emailSha256 = "1234567"
         let advertisingId = "123"
-        
+
+        // Act
         let customer = Order.Customer()
         customer.id = id
         customer.emailSha256 = emailSha256
         customer.advertisingId = advertisingId
-        
+
+        // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertEqual(customer.emailSha256, emailSha256)
         XCTAssertEqual(customer.advertisingId, advertisingId)
     }
     
     func testCustomerInitialization_hashingCapitalizedEmail() {
+        // Arrange
         let id = "123"
         let email = "BETTY@usebutton.com"
         let emailSha256 = "c399e8d0e89e9f09aa14a36392e4cb0d058ab28b16247e80eab78ea5541a20d3"
         let advertisingId = "123"
 
+        // Act
         let customer = Order.Customer()
         customer.id = id
         customer.setEmail(email)
         customer.advertisingId = advertisingId
-        
+
+        // Assert
         XCTAssertEqual(customer.emailSha256, emailSha256)
     }
 
     func testLineItemInitialization_requiredPropertiesOnly() {
+        // Arrange
         let identifier = "unique-id-123"
         let total: Int64 = 4000
-        let quantity = 2
 
-        let lineItem = Order.LineItem(identifier: identifier, total: total, quantity: quantity)
+        // Act
+        let lineItem = Order.LineItem(identifier: identifier, total: total)
 
+        // Assert
         XCTAssertEqual(lineItem.identifier, identifier)
         XCTAssertEqual(lineItem.total, total)
-        XCTAssertEqual(lineItem.quantity, quantity)
+        XCTAssertEqual(lineItem.quantity, 1)
         XCTAssertNil(lineItem.itemDescription)
         XCTAssertNil(lineItem.sku)
         XCTAssertNil(lineItem.upc)
@@ -188,6 +199,7 @@ class OrderTests: XCTestCase {
     }
 
     func testLineItemInitialization_allProperties() {
+        // Arrange
         let identifier = "unique-id-123"
         let total: Int64 = 4000
         let quantity = 2
@@ -197,15 +209,17 @@ class OrderTests: XCTestCase {
         let category = ["Electronics", "Computers"]
         let attributes = ["Model": "MacBook Pro"]
 
+        // Act
         let lineItem = Order.LineItem(identifier: identifier,
-                                       total: total,
-                                       quantity: quantity,
-                                       itemDescription: itemDescription,
-                                       sku: sku,
-                                       upc: upc,
-                                       category: category,
-                                       attributes: attributes)
+                                       total: total)
+        lineItem.quantity = quantity
+        lineItem.itemDescription = itemDescription
+        lineItem.sku = sku
+        lineItem.upc = upc
+        lineItem.category = category
+        lineItem.attributes = attributes
 
+        // Assert
         XCTAssertEqual(lineItem.identifier, identifier)
         XCTAssertEqual(lineItem.total, total)
         XCTAssertEqual(lineItem.quantity, quantity)


### PR DESCRIPTION
### Goals :dart:
Define the Line Item model used in the Order model.

### Implementation Details :construction:
Added the following properties:
* identifier
* total
* quantity
* itemDescription
* sku
* upc
* category
* attributes

### Testing Details :mag:
Added unit tests for the new model
