### PR TITLE
Remove advertising Id and emailSha256

### DIFF
--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -59,7 +59,7 @@ final public class Order: NSObject, Codable {
     /**
      The customer related to the order
      */
-    public var customer: Customer = Customer()
+    public var customer: Customer?
 
     /**
      The total order value in pennies (e.g. 3999 for $39.99)
@@ -120,38 +120,23 @@ final public class Order: NSObject, Codable {
         /**
          The id for the transacting customer in your system (required).
          */
-        public var id: String?
-        
-        /**
-         If you prefer to provide your own hashed email, you can set it here following the below instructions,
-         otherwise, use **setEmail(email:)** and we will hash it for you.
+        let id: String
 
+        /**
          The SHA-256 hash of the transacting customer’s lowercase email, as a 64-character hex string.
-         The value of the e-mail address must be converted to lowercase before computing the hash.
-         The hash itself may use uppercase or lowercase hex characters.
-         */
-        public var emailSha256: String?
 
-        /**
-         The email of the transacting customer.
-         Providing a value for this field will generate a SHA-256 hash
-         and populate the **emailSha256** field for you.
+         **Note**: The value of the e-mail address must be converted to lowercase before
+         computing the hash. The hash itself may use uppercase or lowercase hex characters.
+        */
+        var email: String?
 
-         - Parameter email: the plain-text email to be converted to SHA-256 hash.
-         */
-        public func setEmail(_ email: String) {
-            emailSha256 = email.lowercased().sha256
+        @objc public init(id: String) {
+            self.id = id
         }
-        
-        /**
-         The customer’s IDFA.
-         */
-        public var advertisingId: String?
-        
+
         enum CodingKeys: String, CodingKey {
+            case email
             case id
-            case emailSha256 = "email_sha256"
-            case advertisingId = "advertising_id"
         }
     }
 

--- a/Tests/UnitTests/OrderTests.swift
+++ b/Tests/UnitTests/OrderTests.swift
@@ -27,7 +27,7 @@ import XCTest
 
 class OrderTests: XCTestCase {
     
-    func testInitialization_requiredProperties() {
+    func testInitialization_requiredPropertiesOnly() {
         // Arrange
         let id = "order-abc"
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
@@ -43,7 +43,7 @@ class OrderTests: XCTestCase {
         XCTAssertEqual(order.currencyCode, "USD")
         XCTAssertEqual(order.purchaseDate, date.ISO8601String)
         XCTAssertEqual(order.lineItems, lineItems)
-        XCTAssertNotNil(order.customer)
+        XCTAssertNil(order.customer)
         XCTAssertNil(order.customerOrderId)
     }
 
@@ -54,8 +54,9 @@ class OrderTests: XCTestCase {
         let currencyCode = "EUR"
         let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 400)]
         let customerOrderId = "123"
-        let customer = Order.Customer()
-        
+        let customer = Order.Customer(id: "123")
+
+        // Act
         let order = Order(id: id,
                           purchaseDate: date,
                           lineItems: lineItems)
@@ -86,7 +87,7 @@ class OrderTests: XCTestCase {
 
         let currencyCode = "EUR"
         let customerOrderId = "123"
-        let customer = Order.Customer()
+        let customer = Order.Customer(id: "123")
 
         // Act
         order.currencyCode = currencyCode
@@ -105,15 +106,13 @@ class OrderTests: XCTestCase {
         let id = "derp123"
         let amount: Int64 = 499
         let lineItems: [Order.LineItem] = []
-        let customerDictionary: [String: AnyHashable] = [:]
         let order = Order(id: id, amount: amount)
         let date = order.purchaseDate
         let expectedOrderDictionary: [String: AnyHashable] = ["order_id": id,
                                                               "amount": amount,
                                                               "currency": "USD",
                                                               "purchase_date": date,
-                                                              "line_items": lineItems,
-                                                              "customer": customerDictionary]
+                                                              "line_items": lineItems]
 
         // Act
         guard let actualOrderDictionary = order.dictionaryRepresentation as? [String: AnyHashable] else {
@@ -125,58 +124,30 @@ class OrderTests: XCTestCase {
         XCTAssertEqual(expectedOrderDictionary, actualOrderDictionary)
     }
     
-    func testCustomerInitialization_hashingEmail() {
+    func testCustomerInitialization_requiredPropertiesOnly() {
+        // Arrange
+        let id = "123"
+
+        // Act
+        let customer = Order.Customer(id: id)
+
+        // Assert
+        XCTAssertEqual(customer.id, id)
+        XCTAssertNil(customer.email)
+    }
+
+    func testCustomerInitialization_allProperties() {
         // Arrange
         let id = "123"
         let email = "betty@usebutton.com"
-        let emailSha256 = "c399e8d0e89e9f09aa14a36392e4cb0d058ab28b16247e80eab78ea5541a20d3"
-        let advertisingId = "123"
 
         // Act
-        let customer = Order.Customer()
-        customer.id = id
-        customer.setEmail(email)
-        customer.advertisingId = advertisingId
+        let customer = Order.Customer(id: id)
+        customer.email = email
 
         // Assert
         XCTAssertEqual(customer.id, id)
-        XCTAssertEqual(customer.emailSha256, emailSha256)
-        XCTAssertEqual(customer.advertisingId, advertisingId)
-    }
-    
-    func testCustomerInitialization_providingHashedEmail() {
-        // Arrange
-        let id = "123"
-        let emailSha256 = "1234567"
-        let advertisingId = "123"
-
-        // Act
-        let customer = Order.Customer()
-        customer.id = id
-        customer.emailSha256 = emailSha256
-        customer.advertisingId = advertisingId
-
-        // Assert
-        XCTAssertEqual(customer.id, id)
-        XCTAssertEqual(customer.emailSha256, emailSha256)
-        XCTAssertEqual(customer.advertisingId, advertisingId)
-    }
-    
-    func testCustomerInitialization_hashingCapitalizedEmail() {
-        // Arrange
-        let id = "123"
-        let email = "BETTY@usebutton.com"
-        let emailSha256 = "c399e8d0e89e9f09aa14a36392e4cb0d058ab28b16247e80eab78ea5541a20d3"
-        let advertisingId = "123"
-
-        // Act
-        let customer = Order.Customer()
-        customer.id = id
-        customer.setEmail(email)
-        customer.advertisingId = advertisingId
-
-        // Assert
-        XCTAssertEqual(customer.emailSha256, emailSha256)
+        XCTAssertEqual(customer.email, email)
     }
 
     func testLineItemInitialization_requiredPropertiesOnly() {


### PR DESCRIPTION
### Goals :dart:
Remove redundancies from the `Customer` model.

### Implementation Details :construction:
* Removed `advertisingId`
* Removed `emailSha256` property
* Made `id` required via initializer for `Customer`
* Made `customer` an optional property on `Order`

### Testing Details :mag:
* Model tests were updated

