### PR TITLE
Deprecate trackOrder and Add reportOrder

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -173,8 +173,8 @@ trailing_whitespace:
   ignores_comments: true
 
 type_body_length:
-  warning: 300
-  error: 350
+  warning: 400
+  error: 450
 
 unused_optional_binding:
   severity: error

--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		DADE90C2209B9A630073144B /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADE90C1209B9A630073144B /* TestError.swift */; };
 		DAE8B96F22AF5F0700D11AF9 /* TrustEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */; };
 		DC4AAD4422B13CD3005CE460 /* OrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4AAD4322B13CD3005CE460 /* OrderTests.swift */; };
+		DCF4AD0422B421FB000DA3B2 /* ReportOrderBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4AD0322B421FB000DA3B2 /* ReportOrderBody.swift */; };
+		DCF4AD0722B7E31C000DA3B2 /* ReportOrderBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4AD0522B7E2FF000DA3B2 /* ReportOrderBodyTests.swift */; };
 		DE0E7C2B209B915E001A5EE0 /* ApplicationId.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0E7C2A209B915E001A5EE0 /* ApplicationId.generated.swift */; };
 		DE1706DB20855B06009FF30B /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1706DA20855B06009FF30B /* UIDeviceExtensions.swift */; };
 		DE1706DD20855B22009FF30B /* UIScreenExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1706DC20855B22009FF30B /* UIScreenExtensions.swift */; };
@@ -219,6 +221,8 @@
 		DADE90C1209B9A630073144B /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrustEvaluator.swift; sourceTree = "<group>"; };
 		DC4AAD4322B13CD3005CE460 /* OrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTests.swift; sourceTree = "<group>"; };
+		DCF4AD0322B421FB000DA3B2 /* ReportOrderBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportOrderBody.swift; sourceTree = "<group>"; };
+		DCF4AD0522B7E2FF000DA3B2 /* ReportOrderBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportOrderBodyTests.swift; sourceTree = "<group>"; };
 		DDA5C34AC9410445D780EB22 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		DE0E7C2A209B915E001A5EE0 /* ApplicationId.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationId.generated.swift; sourceTree = "<group>"; };
 		DE153DA4FDE6DCF451A438B1 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -370,6 +374,7 @@
 				DE175A1D20A0ADF7005C97B9 /* Version */,
 				607FACEB1AFB9204008FA782 /* ButtonMerchantTests.swift */,
 				9E4C496520616B040053E4CA /* CoreTests.swift */,
+				DCF4AD0522B7E2FF000DA3B2 /* ReportOrderBodyTests.swift */,
 				9E4C496620616B040053E4CA /* ButtonDefaultsTests.swift */,
 				9E0DBB1B207BB55A0066A35D /* SystemTests.swift */,
 				9E5475E1206D7E0C00947A1C /* ClientTests.swift */,
@@ -576,6 +581,7 @@
 			children = (
 				DE175A1920A09BB1005C97B9 /* Version */,
 				DE865F792052F90600F4054D /* ButtonMerchant.swift */,
+				DCF4AD0322B421FB000DA3B2 /* ReportOrderBody.swift */,
 				DA0FA29F205C1B3A008296A6 /* Core.swift */,
 				9E77202120605506005F740B /* ButtonDefaults.swift */,
 				9EB1B09F207AB43E00BE0A1A /* System.swift */,
@@ -1104,6 +1110,7 @@
 				9EB1B0A0207AB43E00BE0A1A /* System.swift in Sources */,
 				DAE8B96F22AF5F0700D11AF9 /* TrustEvaluator.swift in Sources */,
 				DE2F7450208F6552001E4BD6 /* ConfigurationError.swift in Sources */,
+				DCF4AD0422B421FB000DA3B2 /* ReportOrderBody.swift in Sources */,
 				DE865FA620530BCE00F4054D /* ButtonMerchant.swift in Sources */,
 				9E56CE5A22B812AE00E75884 /* StringExtensions.swift in Sources */,
 				9E2B4317206C1335009F2886 /* EncodableExtensions.swift in Sources */,
@@ -1157,6 +1164,7 @@
 				9E4C496820616B040053E4CA /* ButtonDefaultsTests.swift in Sources */,
 				9E6F4341206C160C004242A1 /* TestClient.swift in Sources */,
 				9E4C496720616B040053E4CA /* CoreTests.swift in Sources */,
+				DCF4AD0722B7E31C000DA3B2 /* ReportOrderBodyTests.swift in Sources */,
 				DEE61B2D20656A090039E47A /* XCTestExtensions.swift in Sources */,
 				9E77202520607331005F740B /* ButtonMerchantTests.swift in Sources */,
 				9EDEB859206ECE3000D58FE2 /* PostInstallBodyTests.swift in Sources */,

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -143,8 +143,23 @@ final public class ButtonMerchant: NSObject {
      This does not replace server-side order reporting to Button.
      [See: order reporting](https://developer.usebutton.com/guides/merchants/ios/report-orders-to-button#report-orders-to-buttons-order-api)
      */
+    @available(*, deprecated, message: "Use reportOrder() instead")
     @objc public static func trackOrder(_ order: Order, completion: ((Error?) -> Void)? = nil) {
         core.trackOrder(order, completion)
+    }
+    
+    /**
+     Tracks an order.
+     
+     This signal is used to power the Instant Rewards feature for Publishers to notify
+     their customer as quickly as possible that their order has been correctly tracked.
+     
+     - Attention:
+     This does not replace server-side order reporting to Button.
+     [See: order reporting](https://developer.usebutton.com/guides/merchants/ios/report-orders-to-button#report-orders-to-buttons-order-api)
+    */
+    @objc public static func reportOrder(_ order: Order, completion: ((Error?) -> Void)? = nil) {
+        core.reportOrder(order, completion)
     }
 
     /**

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -143,13 +143,13 @@ final public class ButtonMerchant: NSObject {
      This does not replace server-side order reporting to Button.
      [See: order reporting](https://developer.usebutton.com/guides/merchants/ios/report-orders-to-button#report-orders-to-buttons-order-api)
      */
-    @available(*, deprecated, message: "Use reportOrder() instead")
+    @available(*, deprecated, message: "Use ButtonMerchant.reportOrder(order:completion:) instead")
     @objc public static func trackOrder(_ order: Order, completion: ((Error?) -> Void)? = nil) {
         core.trackOrder(order, completion)
     }
     
     /**
-     Tracks an order.
+     Reports an order.
      
      This signal is used to power the Instant Rewards feature for Publishers to notify
      their customer as quickly as possible that their order has been correctly tracked.

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -42,6 +42,7 @@ internal protocol ClientType: class {
     var userAgent: UserAgentType { get }
     func fetchPostInstallURL(parameters: [String: Any], _ completion: @escaping (URL?, String?) -> Void)
     func trackOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?)
+    func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?)
     init(session: URLSessionType, userAgent: UserAgentType)
 }
 
@@ -69,7 +70,8 @@ internal final class Client: ClientType {
             completion(URL(string: action)!, attributionObject["btn_ref"] as? String)
         })
     }
-
+    
+    @available(*, deprecated, message: "Use reportOrder() instead")
     func trackOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
         let request = urlRequest(url: Service.activity.url, parameters: parameters)
         enqueueRequest(request: request) { _, error in
@@ -78,6 +80,16 @@ internal final class Client: ClientType {
             }
         }
     }
+    
+    func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
+        let request = urlRequest(url: Service.activity.url, parameters: parameters)
+        enqueueRequest(request: request) { _, error in
+            if let completion = completion {
+                completion(error)
+            }
+        }
+    }
+    
 }
 
 internal extension Client {

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -71,7 +71,6 @@ internal final class Client: ClientType {
         })
     }
     
-    @available(*, deprecated, message: "Use reportOrder() instead")
     func trackOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
         let request = urlRequest(url: Service.activity.url, parameters: parameters)
         enqueueRequest(request: request) { _, error in

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -29,6 +29,7 @@ internal enum Service: String {
     
     case postInstall = "v1/web/deferred-deeplink"
     case activity = "v1/activity/order"
+    case order = "v1/mobile-order"
     
     static var baseURL = "https://api.usebutton.com/"
     
@@ -81,7 +82,7 @@ internal final class Client: ClientType {
     }
     
     func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
-        let request = urlRequest(url: Service.activity.url, parameters: parameters)
+        let request = urlRequest(url: Service.order.url, parameters: parameters)
         enqueueRequest(request: request) { _, error in
             if let completion = completion {
                 completion(error)

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -36,6 +36,7 @@ internal protocol CoreType {
     func trackIncomingURL(_ url: URL)
     func handlePostInstallURL(_ completion: @escaping (URL?, Error?) -> Void)
     func trackOrder(_ order: Order, _ completion: ((Error?) -> Void)?)
+    func reportOrder(_ order: Order, _ completion: ((Error?) -> Void)?)
     init(buttonDefaults: ButtonDefaultsType,
          client: ClientType,
          system: SystemType,
@@ -138,8 +139,8 @@ final internal class Core: CoreType {
             completion(url, nil)
         }
     }
-
-    @available(*, deprecated)
+    
+    @available(*, deprecated, message: "Use reportOrder() instead")
     func trackOrder(_ order: Order, _ completion: ((Error?) -> Void)?) {
         guard let appId = applicationId, !appId.isEmpty else {
             if let completion = completion {
@@ -156,6 +157,21 @@ final internal class Core: CoreType {
         let parameters = trackOrderBody.dictionaryRepresentation
 
         client.trackOrder(parameters: parameters, completion)
+    }
+    
+    func reportOrder(_ order: Order, _ completion: ((Error?) -> Void)?) {
+        guard let appId = applicationId, !appId.isEmpty else {
+            if let completion = completion {
+                completion(ConfigurationError.noApplicationId)
+            }
+            return
+        }
+        
+        let trackOrderBody = TrackOrderBody(system: system, applicationId: appId, attributionToken: buttonDefaults.attributionToken, order: order)
+        
+        let parameters = trackOrderBody.dictionaryRepresentation
+        
+        client.reportOrder(parameters: parameters, completion)
     }
 
 }

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -140,7 +140,7 @@ final internal class Core: CoreType {
         }
     }
     
-    @available(*, deprecated, message: "Use reportOrder() instead")
+    @available(*, deprecated)
     func trackOrder(_ order: Order, _ completion: ((Error?) -> Void)?) {
         guard let appId = applicationId, !appId.isEmpty else {
             if let completion = completion {
@@ -167,10 +167,10 @@ final internal class Core: CoreType {
             return
         }
         
-        let trackOrderBody = TrackOrderBody(system: system, applicationId: appId, attributionToken: buttonDefaults.attributionToken, order: order)
+        let reportOrderBody = ReportOrderBody(system: system, applicationId: appId, attributionToken: buttonDefaults.attributionToken, order: order)
         
-        let parameters = trackOrderBody.dictionaryRepresentation
-        
+        let parameters = reportOrderBody.dictionaryRepresentation
+
         client.reportOrder(parameters: parameters, completion)
     }
 

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -26,7 +26,7 @@ import Foundation
 import CommonCrypto
 
 /**
-Represents an order placed by the user to be tracked using `ButtonMerchant.trackOrder(order)`.
+Represents an order placed by the user to be tracked using `ButtonMerchant.reportOrder(order)`.
  */
 @objcMembers
 final public class Order: NSObject, Codable {
@@ -59,7 +59,7 @@ final public class Order: NSObject, Codable {
     /**
      The customer related to the order
      */
-    public var customer: Customer = Customer()
+    public var customer: Customer?
 
     /**
      The total order value in pennies (e.g. 3999 for $39.99)

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -59,7 +59,7 @@ final public class Order: NSObject, Codable {
     /**
      The customer related to the order
      */
-    public var customer: Customer?
+    public var customer: Customer = Customer()
 
     /**
      The total order value in pennies (e.g. 3999 for $39.99)

--- a/Source/ReportOrderBody.swift
+++ b/Source/ReportOrderBody.swift
@@ -1,0 +1,69 @@
+//
+// ReportOrderBody.swift
+//
+// Copyright © 2019 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+internal struct ReportOrderBody: Codable {
+    
+    let applicationId: String
+    let userLocalTime: String
+    let attributionToken: String?
+    let orderId: String
+    let currency: String
+    let purchaseDate: String
+    let customerOrderId: String?
+    let lineItems: [Order.LineItem]?
+    let customer: Order.Customer?
+    let source: String = "merchant-library"
+    
+    enum CodingKeys: String, CodingKey {
+        case applicationId = "app_id"
+        case userLocalTime = "user_local_time"
+        case attributionToken = "btn_ref"
+        case orderId = "order_id"
+        case currency
+        case purchaseDate = "purchase_date"
+        case customerOrderId = "customer_order_id"
+        case lineItems = "line_items"
+        case customer
+        case source
+    }
+    
+    init(system: SystemType,
+         applicationId: String,
+         attributionToken: String?,
+         order: Order) {
+        
+        self.applicationId = applicationId
+        userLocalTime = system.currentDate.ISO8601String
+        self.attributionToken = attributionToken
+        self.orderId = order.id
+        self.currency = order.currencyCode
+        self.purchaseDate = order.purchaseDate
+        self.customerOrderId = order.customerOrderId
+        self.lineItems = order.lineItems
+        self.customer = order.customer
+    }
+
+}

--- a/Source/ReportOrderBody.swift
+++ b/Source/ReportOrderBody.swift
@@ -26,8 +26,6 @@ import Foundation
 
 internal struct ReportOrderBody: Codable {
     
-    let applicationId: String
-    let userLocalTime: String
     let attributionToken: String?
     let orderId: String
     let currency: String
@@ -35,11 +33,8 @@ internal struct ReportOrderBody: Codable {
     let customerOrderId: String?
     let lineItems: [Order.LineItem]?
     let customer: Order.Customer?
-    let source: String = "merchant-library"
     
     enum CodingKeys: String, CodingKey {
-        case applicationId = "app_id"
-        case userLocalTime = "user_local_time"
         case attributionToken = "btn_ref"
         case orderId = "order_id"
         case currency
@@ -47,16 +42,13 @@ internal struct ReportOrderBody: Codable {
         case customerOrderId = "customer_order_id"
         case lineItems = "line_items"
         case customer
-        case source
     }
     
     init(system: SystemType,
          applicationId: String,
          attributionToken: String?,
          order: Order) {
-        
-        self.applicationId = applicationId
-        userLocalTime = system.currentDate.ISO8601String
+
         self.attributionToken = attributionToken
         self.orderId = order.id
         self.currency = order.currencyCode

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -171,7 +171,9 @@ class ButtonMerchantTests: XCTestCase {
                                 client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
                                 system: testSystem,
                                 notificationCenter: TestNotificationCenter())
-        let expectedOrder = Order(id: "test", purchaseDate: Date(), lineItems: [Order.LineItem(identifier: "unique-id-1234", total: 400, quantity: 2)])
+        let expectedOrder = Order(id: "test",
+                                  purchaseDate: Date(),
+                                  lineItems: [Order.LineItem(identifier: "unique-id-1234", total: 400)])
         
         // Act
         ButtonMerchant._core = testCore

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -163,4 +163,21 @@ class ButtonMerchantTests: XCTestCase {
         // Assert
         XCTAssertEqual(testCore.testOrder, expectedOrder)
     }
+    
+    func testReportOrderInvokesCoreWithOrder() {
+        // Arrange
+        let testSystem = TestSystem()
+        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                                client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
+                                system: testSystem,
+                                notificationCenter: TestNotificationCenter())
+        let expectedOrder = Order(id: "test", purchaseDate: Date(), lineItems: [Order.LineItem(identifier: "unique-id-1234", total: 400, quantity: 2)])
+        
+        // Act
+        ButtonMerchant._core = testCore
+        ButtonMerchant.reportOrder(expectedOrder) { _ in }
+        
+        // Assert
+        XCTAssertEqual(testCore.testOrder, expectedOrder)
+    }
 }

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -319,10 +319,7 @@ class ClientTests: XCTestCase {
         
         // Assert
         XCTAssertTrue(testURLSession.didCallDataTaskWithRequest)
-        XCTAssertNotNil(testURLSession.lastDataTask)
-        XCTAssertNotNil(testURLSession.lastDataTask?.originalRequest!.url)
         XCTAssertEqual(testURLSession.lastDataTask?.originalRequest!.url, expectedURL)
-        XCTAssertNotNil(parameters)
         XCTAssertEqual(parameters!, expectedParameters)
     }
     

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -328,7 +328,7 @@ class ClientTests: XCTestCase {
     
     func testReportOrderSuccess() {
         // Arrange
-        let expectation = XCTestExpectation(description: "track order success")
+        let expectation = XCTestExpectation(description: "report order success")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
         let url = URL(string: "https://api.usebutton.com/v1/activity/order")!
@@ -349,14 +349,14 @@ class ClientTests: XCTestCase {
     
     func testReportOrderFails() {
         // Arrange
-        let expectation = XCTestExpectation(description: "track order fails")
+        let expectation = XCTestExpectation(description: "report order fails")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
         let url = URL(string: "https://api.usebutton.com/v1/activity/order")!
         let expectedError = TestError.known
         
         // Act
-        client.trackOrder(parameters: [:]) { error in
+        client.reportOrder(parameters: [:]) { error in
             
             // Assert
             XCTAssertNotNil(error)

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -309,7 +309,7 @@ class ClientTests: XCTestCase {
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
         let expectedParameters = ["blargh": "blergh"]
-        let expectedURL = URL(string: "https://api.usebutton.com/v1/activity/order")!
+        let expectedURL = URL(string: "https://api.usebutton.com/v1/mobile-order")!
         
         // Act
         client.reportOrder(parameters: expectedParameters) { _ in }
@@ -328,7 +328,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "report order success")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
-        let url = URL(string: "https://api.usebutton.com/v1/activity/order")!
+        let url = URL(string: "https://api.usebutton.com/v1/mobile-order")!
         
         // Act
         client.reportOrder(parameters: [:]) { error in
@@ -349,7 +349,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "report order fails")
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
-        let url = URL(string: "https://api.usebutton.com/v1/activity/order")!
+        let url = URL(string: "https://api.usebutton.com/v1/mobile-order")!
         let expectedError = TestError.known
         
         // Act

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -408,16 +408,13 @@ class CoreTests: XCTestCase {
         }
 
         XCTAssertEqual(testClient.testParameters as NSDictionary,
-                       ["app_id": "app-abc123",
-                        "user_local_time": "2018-01-23T12:00:00Z",
-                        "btn_ref": "srctok-abc123",
+                       ["btn_ref": "srctok-abc123",
                         "order_id": "order-abc",
                         "currency": "USD",
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email": email],
-                        "source": "merchant-library"])
+                        "customer": ["id": "customer-id-123", "email": email]])
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)
@@ -454,15 +451,12 @@ class CoreTests: XCTestCase {
         }
 
         XCTAssertEqual(testClient.testParameters as NSDictionary,
-                       ["app_id": "app-abc123",
-                        "user_local_time": "2018-01-23T12:00:00Z",
-                        "order_id": "order-abc",
+                       ["order_id": "order-abc",
                         "currency": "USD",
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email": email],
-                        "source": "merchant-library"])
+                        "customer": ["id": "customer-id-123", "email": email]])
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)

--- a/Tests/UnitTests/OrderTests.swift
+++ b/Tests/UnitTests/OrderTests.swift
@@ -106,6 +106,7 @@ class OrderTests: XCTestCase {
         let id = "derp123"
         let amount: Int64 = 499
         let lineItems: [Order.LineItem] = []
+        let customerDictionary: [String: AnyHashable] = [:]
         let order = Order(id: id, amount: amount)
         let date = order.purchaseDate
         let expectedOrderDictionary: [String: AnyHashable] = ["order_id": id,

--- a/Tests/UnitTests/ReportOrderBodyTests.swift
+++ b/Tests/UnitTests/ReportOrderBodyTests.swift
@@ -42,8 +42,6 @@ class ReportOrderBodyTests: XCTestCase {
                                   order: order)
         
         // Assert
-        XCTAssertEqual(body.applicationId, "app-abc123")
-        XCTAssertEqual(body.userLocalTime, "2018-01-23T12:00:00Z")
         XCTAssertEqual(body.attributionToken, "srctok-abc123")
         XCTAssertEqual(body.orderId, order.id)
         XCTAssertEqual(body.currency, order.currencyCode)
@@ -51,7 +49,6 @@ class ReportOrderBodyTests: XCTestCase {
         XCTAssertEqual(body.customerOrderId, order.customerOrderId)
         XCTAssertEqual(body.lineItems, body.lineItems)
         XCTAssertEqual(body.customer, body.customer)
-        XCTAssertEqual(body.source, "merchant-library")
     }
 
     func testSerializationToDictionary() {
@@ -74,16 +71,13 @@ class ReportOrderBodyTests: XCTestCase {
         
         // Assert
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
-                       ["app_id": "app-abc123",
-                        "user_local_time": "2018-01-23T12:00:00Z",
-                        "btn_ref": "srctok-abc123",
+                       ["btn_ref": "srctok-abc123",
                         "order_id": "order-abc",
                         "currency": "USD",
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email": email],
-                        "source": "merchant-library"])
+                        "customer": ["id": "customer-id-123", "email": email]])
     }
     
 }

--- a/Tests/UnitTests/ReportOrderBodyTests.swift
+++ b/Tests/UnitTests/ReportOrderBodyTests.swift
@@ -1,0 +1,89 @@
+//
+// ReportOrderBodyTests.swift
+//
+// Copyright © 2019 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import XCTest
+@testable import ButtonMerchant
+
+class ReportOrderBodyTests: XCTestCase {
+    
+    func testInitialization() {
+        // Arrange
+        let date = Date()
+        let customer = Order.Customer(id: "customer-id-123")
+        customer.email = "test@button.com"
+        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 120)]
+        let order = Order(id: "order-abc", purchaseDate: date, lineItems: lineItems)
+        
+        // Act
+        let body = ReportOrderBody(system: TestSystem(),
+                                  applicationId: "app-abc123",
+                                  attributionToken: "srctok-abc123",
+                                  order: order)
+        
+        // Assert
+        XCTAssertEqual(body.applicationId, "app-abc123")
+        XCTAssertEqual(body.userLocalTime, "2018-01-23T12:00:00Z")
+        XCTAssertEqual(body.attributionToken, "srctok-abc123")
+        XCTAssertEqual(body.orderId, order.id)
+        XCTAssertEqual(body.currency, order.currencyCode)
+        XCTAssertEqual(body.purchaseDate, order.purchaseDate)
+        XCTAssertEqual(body.customerOrderId, order.customerOrderId)
+        XCTAssertEqual(body.lineItems, body.lineItems)
+        XCTAssertEqual(body.customer, body.customer)
+        XCTAssertEqual(body.source, "merchant-library")
+    }
+
+    func testSerializationToDictionary() {
+        // Arrange
+        Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
+        let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
+        let email = "test@button.com"
+        let customer = Order.Customer(id: "customer-id-123")
+        customer.email = email
+        let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 120)]
+        let order = Order(id: "order-abc", purchaseDate: date, lineItems: lineItems)
+        order.customer = customer
+        order.customerOrderId = "customer-order-id-123"
+        
+        // Act
+        let body = ReportOrderBody(system: TestSystem(),
+                                  applicationId: "app-abc123",
+                                  attributionToken: "srctok-abc123",
+                                  order: order)
+        
+        // Assert
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       ["app_id": "app-abc123",
+                        "user_local_time": "2018-01-23T12:00:00Z",
+                        "btn_ref": "srctok-abc123",
+                        "order_id": "order-abc",
+                        "currency": "USD",
+                        "purchase_date": date.ISO8601String,
+                        "customer_order_id": "customer-order-id-123",
+                        "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
+                        "customer": ["id": "customer-id-123", "email": email],
+                        "source": "merchant-library"])
+    }
+    
+}

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -55,4 +55,10 @@ class TestClient: ClientType {
         didCallTrackOrder = true
         trackOrderCompletion = completion
     }
+    
+    func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
+        testParameters = parameters
+        didCallTrackOrder = true
+        trackOrderCompletion = completion
+    }
 }

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -31,12 +31,14 @@ class TestClient: ClientType {
     var testParameters: [String: Any]
     var didCallGetPostInstallLink = false
     var didCallTrackOrder = false
+    var didCallReportOrder = false
 
     var session: URLSessionType
     var userAgent: UserAgentType
 
     var postInstallCompletion: ((URL?, String?) -> Void)?
     var trackOrderCompletion: ((Error?) -> Void)?
+    var reportOrderCompletion: ((Error?) -> Void)?
 
     required init(session: URLSessionType, userAgent: UserAgentType) {
         self.session = session
@@ -58,7 +60,7 @@ class TestClient: ClientType {
     
     func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
         testParameters = parameters
-        didCallTrackOrder = true
-        trackOrderCompletion = completion
+        didCallReportOrder = true
+        reportOrderCompletion = completion
     }
 }

--- a/Tests/UnitTests/TestObjects/TestCore.swift
+++ b/Tests/UnitTests/TestObjects/TestCore.swift
@@ -74,6 +74,10 @@ class TestCore: CoreType {
         testOrder = order
     }
     
+    func reportOrder(_ order: Order, _ completion: ((Error?) -> Void)?) {
+        testOrder = order
+    }
+    
     func trackIncomingURL(_ url: URL) {
         testUrl = url
     }


### PR DESCRIPTION
### Goals :dart:
Add `reportOrder` and deprecate `trackOrder`.

### Implementation Details :construction:
`reportOrder` uses the updated `Order` model.

### Testing Details :mag:
Added unit test for `reportOrder`. 

