### PR TITLE
Encode Customer Email

### DIFF
--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		9E2B4315206C12BC009F2886 /* URLSessionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2B4313206C12BC009F2886 /* URLSessionExtensions.swift */; };
 		9E2B4317206C1335009F2886 /* EncodableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2B4316206C1335009F2886 /* EncodableExtensions.swift */; };
 		9E2B431B206C134A009F2886 /* PostInstallBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2B4319206C134A009F2886 /* PostInstallBody.swift */; };
+		9E334DB822C2A62300F697DE /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E334DB722C2A62300F697DE /* StringTests.swift */; };
 		9E4C496720616B040053E4CA /* CoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4C496520616B040053E4CA /* CoreTests.swift */; };
 		9E4C496820616B040053E4CA /* ButtonDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4C496620616B040053E4CA /* ButtonDefaultsTests.swift */; };
 		9E4C496B20616B130053E4CA /* TestUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4C496920616B130053E4CA /* TestUserDefaults.swift */; };
@@ -153,6 +154,7 @@
 		9E2B4313206C12BC009F2886 /* URLSessionExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionExtensions.swift; sourceTree = "<group>"; };
 		9E2B4316206C1335009F2886 /* EncodableExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncodableExtensions.swift; sourceTree = "<group>"; };
 		9E2B4319206C134A009F2886 /* PostInstallBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostInstallBody.swift; sourceTree = "<group>"; };
+		9E334DB722C2A62300F697DE /* StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		9E4C496520616B040053E4CA /* CoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreTests.swift; sourceTree = "<group>"; };
 		9E4C496620616B040053E4CA /* ButtonDefaultsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonDefaultsTests.swift; sourceTree = "<group>"; };
 		9E4C496920616B130053E4CA /* TestUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUserDefaults.swift; sourceTree = "<group>"; };
@@ -549,6 +551,7 @@
 			children = (
 				DA29D891209CDC3100537806 /* URLSessionTests.swift */,
 				DA29D893209CF34D00537806 /* UIDeviceTests.swift */,
+				9E334DB722C2A62300F697DE /* StringTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1156,6 +1159,7 @@
 				DA756B7122B2BB3A003397E3 /* ValidationStrategyTests.swift in Sources */,
 				9E4C496C20616B130053E4CA /* TestButtonDefaults.swift in Sources */,
 				9EDED110208FA3930049A56A /* UserAgentTests.swift in Sources */,
+				9E334DB822C2A62300F697DE /* StringTests.swift in Sources */,
 				DA0FA2A3205C1EF2008296A6 /* TestCore.swift in Sources */,
 				DA29D894209CF34D00537806 /* UIDeviceTests.swift in Sources */,
 				DE1706E920856417009FF30B /* TestAdIdManager.swift in Sources */,

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -27,6 +27,10 @@ import CommonCrypto
 
 public extension String {
 
+    var isPlainTextEmail: Bool {
+        return NSPredicate(format: "SELF MATCHES %@", "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}").evaluate(with: self)
+    }
+
     var sha256: String {
         guard let stringData = self.data(using: .utf8) else {
             return ""

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -128,7 +128,14 @@ final public class Order: NSObject, Codable {
          **Note**: The value of the e-mail address must be converted to lowercase before
          computing the hash. The hash itself may use uppercase or lowercase hex characters.
         */
-        var email: String?
+        public var email: String? {
+            didSet {
+                guard let email = self.email else { return }
+                if email.isPlainTextEmail {
+                    self.email = email.sha256
+                }
+            }
+        }
 
         @objc public init(id: String) {
             self.id = id

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -130,9 +130,11 @@ final public class Order: NSObject, Codable {
         */
         public var email: String? {
             didSet {
-                guard let email = self.email else { return }
+                guard let email = self.email else {
+                    return
+                }
                 if email.isPlainTextEmail {
-                    self.email = email.sha256
+                    self.email = email.lowercased().sha256
                 }
             }
         }
@@ -142,8 +144,8 @@ final public class Order: NSObject, Codable {
         }
 
         enum CodingKeys: String, CodingKey {
-            case email
             case id
+            case email = "email_sha256"
         }
     }
 

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -382,10 +382,9 @@ class CoreTests: XCTestCase {
         let expectation = XCTestExpectation(description: "track order")
         Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
-        let email = "test@button.com"
         let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 120)]
         let customer = Order.Customer(id: "customer-id-123")
-        customer.email = email
+        customer.email = "test@button.com"
         let order = Order(id: "order-abc", purchaseDate: date, lineItems: lineItems)
         order.customer = customer
         order.customerOrderId = "customer-order-id-123"
@@ -414,7 +413,7 @@ class CoreTests: XCTestCase {
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email": email]])
+                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)
@@ -425,9 +424,8 @@ class CoreTests: XCTestCase {
         let expectation = XCTestExpectation(description: "track order")
         Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
-        let email = "test@button.com"
         let customer = Order.Customer(id: "customer-id-123")
-        customer.email = email
+        customer.email = "test@button.com"
         let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 120)]
         let order = Order(id: "order-abc", purchaseDate: date, lineItems: lineItems)
         order.customer = customer
@@ -456,7 +454,7 @@ class CoreTests: XCTestCase {
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email": email]])
+                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)

--- a/Tests/UnitTests/Extensions/StringTests.swift
+++ b/Tests/UnitTests/Extensions/StringTests.swift
@@ -1,0 +1,47 @@
+//
+// StringTests.swift
+//
+// Copyright © 2019 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+	
+import XCTest
+
+class StringTests: XCTestCase {
+
+    func testIsPlainTextEmail_arbitraryString_returnsFalse() {
+        let email = "not_an_email"
+
+        XCTAssertFalse(email.isPlainTextEmail)
+    }
+
+    func testIsPlainTextEmail_hexString_returnsFalse() {
+        let email = "314c70b69a726ae7934806b2a0621a0eb193139e38d9bf6134191faa61b7bb29"
+
+        XCTAssertFalse(email.isPlainTextEmail)
+    }
+
+    func testIsPlainTextEmail_returnsTrue() {
+        let email = "betty@usebutton.com"
+
+        XCTAssertTrue(email.isPlainTextEmail)
+    }
+
+}

--- a/Tests/UnitTests/OrderTests.swift
+++ b/Tests/UnitTests/OrderTests.swift
@@ -106,7 +106,6 @@ class OrderTests: XCTestCase {
         let id = "derp123"
         let amount: Int64 = 499
         let lineItems: [Order.LineItem] = []
-        let customerDictionary: [String: AnyHashable] = [:]
         let order = Order(id: id, amount: amount)
         let date = order.purchaseDate
         let expectedOrderDictionary: [String: AnyHashable] = ["order_id": id,
@@ -137,10 +136,11 @@ class OrderTests: XCTestCase {
         XCTAssertNil(customer.email)
     }
 
-    func testCustomerInitialization_allProperties() {
+    func testCustomerInitialization_allProperties_plainTextEmail() {
         // Arrange
         let id = "123"
         let email = "betty@usebutton.com"
+        let emailSha256 = "c399e8d0e89e9f09aa14a36392e4cb0d058ab28b16247e80eab78ea5541a20d3"
 
         // Act
         let customer = Order.Customer(id: id)
@@ -148,7 +148,21 @@ class OrderTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(customer.id, id)
-        XCTAssertEqual(customer.email, email)
+        XCTAssertEqual(customer.email, emailSha256)
+    }
+
+    func testCustomerInitialization_allProperties_nonPlainTextEmail() {
+        // Arrange
+        let id = "123"
+        let emailSha256 = "c399e8d0e89e9f09aa14a36392e4cb0d058ab28b16247e80eab78ea5541a20d3"
+
+        // Act
+        let customer = Order.Customer(id: id)
+        customer.email = emailSha256
+
+        // Assert
+        XCTAssertEqual(customer.id, id)
+        XCTAssertEqual(customer.email, emailSha256)
     }
 
     func testLineItemInitialization_requiredPropertiesOnly() {

--- a/Tests/UnitTests/ReportOrderBodyTests.swift
+++ b/Tests/UnitTests/ReportOrderBodyTests.swift
@@ -77,7 +77,7 @@ class ReportOrderBodyTests: XCTestCase {
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email": email]])
+                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
     }
     
 }


### PR DESCRIPTION
### Goals :dart:
Ensure that an email passed to the `Customer` model is encoded with SHA-256.

### Implementation Details :construction:
* Extended `String` with:
   * Computed property `isPlainTextEmail: Bool`
* Updated `email` on `Order.Customer` with `didSet` to encode it, if necessary

### Testing Details :mag:
* Added `StringTests` file to test the extension
* Added `Customer` tests for `email`

