### PR TITLE
Add advertisingId

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -181,7 +181,7 @@ unused_optional_binding:
   ignore_optional_try: false
 
 file_length:
-  warning: 500
+  warning: 550
 
 ## Opt-In
 conditional_returns_on_newline: error

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -167,6 +167,8 @@ final internal class Core: CoreType {
             return
         }
         
+        order.customer?.advertisingId = system.adIdManager.advertisingIdentifier.uuidString
+
         let reportOrderBody = ReportOrderBody(system: system, applicationId: appId, attributionToken: buttonDefaults.attributionToken, order: order)
         
         let parameters = reportOrderBody.dictionaryRepresentation

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -146,6 +146,7 @@ final public class Order: NSObject, Codable {
         enum CodingKeys: String, CodingKey {
             case id
             case email = "email_sha256"
+            case advertisingId = "advertising_id"
         }
     }
 

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -413,7 +413,7 @@ class CoreTests: XCTestCase {
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
+                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c", "advertising_id": TestAdIdManager().advertisingIdentifier.uuidString]])
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)
@@ -454,7 +454,7 @@ class CoreTests: XCTestCase {
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
+                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c","advertising_id": TestAdIdManager().advertisingIdentifier.uuidString]])
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)
@@ -506,5 +506,30 @@ class CoreTests: XCTestCase {
             expectation.fulfill()
         }
         XCTAssertEqual(order.customer?.advertisingId, TestAdIdManager().advertisingIdentifier.uuidString)
+    }
+    
+    func testAdvertisingIdNilCustomer() {
+        // Arrange
+        let expectation = XCTestExpectation(description: "tracker order error")
+        let order = Order(id: "order-abc", purchaseDate: Date(), lineItems: [])
+        order.customer = nil
+        let testSystem = TestSystem(adIdManager: TestAdIdManager())
+        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
+        let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
+        testDefaults.testToken = "srctok-abc123"
+        let core = Core(buttonDefaults: testDefaults,
+                        client: testClient,
+                        system: testSystem,
+                        notificationCenter: TestNotificationCenter())
+        core.applicationId = "app-abc123"
+        
+        // Act
+        core.reportOrder(order) { error in
+            
+            // Assert
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        XCTAssertNil(order.customer?.advertisingId)
     }
 }

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -481,4 +481,30 @@ class CoreTests: XCTestCase {
         }
         self.wait(for: [expectation], timeout: 2.0)
     }
+    
+    func testAdvertisingId() {
+        // Arrange
+        let expectation = XCTestExpectation(description: "tracker order error")
+        let order = Order(id: "order-abc", purchaseDate: Date(), lineItems: [])
+        let customer = Order.Customer(id: "customer-id-123")
+        order.customer = customer
+        let testSystem = TestSystem(adIdManager: TestAdIdManager())
+        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
+        let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
+        testDefaults.testToken = "srctok-abc123"
+        let core = Core(buttonDefaults: testDefaults,
+                        client: testClient,
+                        system: testSystem,
+                        notificationCenter: TestNotificationCenter())
+        core.applicationId = "app-abc123"
+        
+        // Act
+        core.reportOrder(order) { error in
+            
+            // Assert
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        XCTAssertEqual(order.customer?.advertisingId, TestAdIdManager().advertisingIdentifier.uuidString)
+    }
 }


### PR DESCRIPTION
### Goals :dart:
Add `advertisingId` to customer as an internal property.

### Implementation Details :construction:
Added the following to customer:
`advertisingId`

### Testing Details :mag:
Added a unit test for `advertisingId`

