### PR TITLE
Encode app id for report order request

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -43,7 +43,7 @@ internal protocol ClientType: class {
     var userAgent: UserAgentType { get }
     func fetchPostInstallURL(parameters: [String: Any], _ completion: @escaping (URL?, String?) -> Void)
     func trackOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?)
-    func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?)
+    func reportOrder(parameters: [String: Any], encodedApplicationId: String, _ completion: ((Error?) -> Void)?)
     init(session: URLSessionType, userAgent: UserAgentType)
 }
 
@@ -81,8 +81,9 @@ internal final class Client: ClientType {
         }
     }
     
-    func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
-        let request = urlRequest(url: Service.order.url, parameters: parameters)
+    func reportOrder(parameters: [String: Any], encodedApplicationId: String, _ completion: ((Error?) -> Void)?) {
+        var request = urlRequest(url: Service.order.url, parameters: parameters)
+        request.setValue("Basic \(encodedApplicationId):", forHTTPHeaderField: "Authorization")
         enqueueRequest(request: request) { _, error in
             if let completion = completion {
                 completion(error)

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -160,7 +160,8 @@ final internal class Core: CoreType {
     }
     
     func reportOrder(_ order: Order, _ completion: ((Error?) -> Void)?) {
-        guard let appId = applicationId, !appId.isEmpty else {
+        guard let appId = applicationId, !appId.isEmpty,
+            let encodedAppId = appId.data(using: .utf8)?.base64EncodedString() else {
             if let completion = completion {
                 completion(ConfigurationError.noApplicationId)
             }
@@ -171,7 +172,7 @@ final internal class Core: CoreType {
         
         let parameters = reportOrderBody.dictionaryRepresentation
 
-        client.reportOrder(parameters: parameters, completion)
+        client.reportOrder(parameters: parameters, encodedApplicationId: encodedAppId, completion)
     }
 
 }

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -310,17 +310,32 @@ class ClientTests: XCTestCase {
         let client = Client(session: testURLSession, userAgent: TestUserAgent())
         let expectedParameters = ["blargh": "blergh"]
         let expectedURL = URL(string: "https://api.usebutton.com/v1/mobile-order")!
-        
+
         // Act
-        client.reportOrder(parameters: expectedParameters) { _ in }
+        client.reportOrder(parameters: expectedParameters, encodedApplicationId: "") { _ in }
         let request = (testURLSession.lastDataTask?.originalRequest)!
         let requestParameters = try? JSONSerialization.jsonObject(with: request.httpBody!)
         let parameters = requestParameters as? [String: String]
-        
+
         // Assert
         XCTAssertTrue(testURLSession.didCallDataTaskWithRequest)
         XCTAssertEqual(testURLSession.lastDataTask?.originalRequest!.url, expectedURL)
         XCTAssertEqual(parameters!, expectedParameters)
+    }
+
+    func testReportOrder_addsAuthorizationHeader() {
+        // Arrange
+        let testURLSession = TestURLSession()
+        let client = Client(session: testURLSession, userAgent: TestUserAgent())
+        let expectedAuthHeader = "Basic encoded_app_id:"
+
+        // Act
+        client.reportOrder(parameters: ["blargh": "blergh"], encodedApplicationId: "encoded_app_id") { _ in }
+        let request = (testURLSession.lastDataTask?.originalRequest)!
+        let authHeaders = request.allHTTPHeaderFields
+
+        // Assert
+        XCTAssertEqual(authHeaders?["Authorization"], expectedAuthHeader)
     }
     
     func testReportOrderSuccess() {
@@ -331,7 +346,7 @@ class ClientTests: XCTestCase {
         let url = URL(string: "https://api.usebutton.com/v1/mobile-order")!
         
         // Act
-        client.reportOrder(parameters: [:]) { error in
+        client.reportOrder(parameters: [:], encodedApplicationId: "") { error in
             
             // Assert
             XCTAssertNil(error)
@@ -353,7 +368,7 @@ class ClientTests: XCTestCase {
         let expectedError = TestError.known
         
         // Act
-        client.reportOrder(parameters: [:]) { error in
+        client.reportOrder(parameters: [:], encodedApplicationId: "") { error in
             
             // Assert
             XCTAssertNotNil(error)

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -379,7 +379,7 @@ class CoreTests: XCTestCase {
     
     func testReportOrder() {
         // Arrange
-        let expectation = XCTestExpectation(description: "track order")
+        let expectation = XCTestExpectation(description: "report order")
         Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
         let lineItems = [Order.LineItem(identifier: "unique-id-1234", total: 120)]
@@ -414,6 +414,7 @@ class CoreTests: XCTestCase {
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
                         "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
+        XCTAssertEqual(testClient.testEncodedApplicationId, "YXBwLWFiYzEyMw==")
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)
@@ -421,7 +422,7 @@ class CoreTests: XCTestCase {
     
     func testReportOrderWithoutAttributionToken() {
         // Arrange
-        let expectation = XCTestExpectation(description: "track order")
+        let expectation = XCTestExpectation(description: "report order")
         Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
         let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
         let customer = Order.Customer(id: "customer-id-123")
@@ -456,13 +457,13 @@ class CoreTests: XCTestCase {
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
                         "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
         testClient.reportOrderCompletion!(nil)
-        
+        XCTAssertEqual(testClient.testEncodedApplicationId, "YXBwLWFiYzEyMw==")
         self.wait(for: [expectation], timeout: 2.0)
     }
     
     func testReportOrderError() {
         // Arrange
-        let expectation = XCTestExpectation(description: "tracker order error")
+        let expectation = XCTestExpectation(description: "report order error")
         let order = Order(id: "order-abc", purchaseDate: Date(), lineItems: [])
         let testSystem = TestSystem()
         let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -29,6 +29,7 @@ class TestClient: ClientType {
 
     // Test properties
     var testParameters: [String: Any]
+    var testEncodedApplicationId: String?
     var didCallGetPostInstallLink = false
     var didCallTrackOrder = false
     var didCallReportOrder = false
@@ -58,8 +59,9 @@ class TestClient: ClientType {
         trackOrderCompletion = completion
     }
     
-    func reportOrder(parameters: [String: Any], _ completion: ((Error?) -> Void)?) {
+    func reportOrder(parameters: [String: Any], encodedApplicationId: String, _ completion: ((Error?) -> Void)?) {
         testParameters = parameters
+        testEncodedApplicationId = encodedApplicationId
         didCallReportOrder = true
         reportOrderCompletion = completion
     }


### PR DESCRIPTION
### Goals :dart:
Encode the application id for all report order requests.

### Implementation Details :construction:
* Updated `reportOrder` method in `Client`
   * Added parameter `encodedApplicationId: String`
   * Set the authorization header
* Updated `reportOrder` method in `Core`
   * Added step to base 64 encode app Id

### Testing Details :mag:
* Added tests for encoded app id

