### PR TITLE
Add report order UI for example app

### DIFF
--- a/Examples/Objective-C/Base.lproj/Main.storyboard
+++ b/Examples/Objective-C/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="y8m-bt-A0T">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="y8m-bt-A0T">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -91,8 +91,25 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="4pW-L9-ISv" style="IBUITableViewCellStyleDefault" id="LrZ-GG-Cy0">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="5Fr-Ga-rrl" style="IBUITableViewCellStyleDefault" id="ojm-8m-XYn">
                                         <rect key="frame" x="0.0" y="223.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ojm-8m-XYn" id="7Wi-Te-H4j">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Report order" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="5Fr-Ga-rrl">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="4pW-L9-ISv" style="IBUITableViewCellStyleDefault" id="LrZ-GG-Cy0">
+                                        <rect key="frame" x="0.0" y="267.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LrZ-GG-Cy0" id="3hF-9A-jN0">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -120,6 +137,7 @@
                     <connections>
                         <outlet property="attributionTokenCell" destination="HdC-La-E8t" id="SRE-Jz-FDB"/>
                         <outlet property="clearAllDataCell" destination="LrZ-GG-Cy0" id="dpv-pr-pB8"/>
+                        <outlet property="reportOrderCell" destination="ojm-8m-XYn" id="MLa-uY-nKc"/>
                         <outlet property="trackIncomingURLCell" destination="I3a-k5-m3p" id="nCb-6u-xO8"/>
                         <outlet property="trackOrderCell" destination="bgu-qA-Ow2" id="HVa-B3-Hs7"/>
                     </connections>

--- a/Examples/Objective-C/Base.lproj/Main.storyboard
+++ b/Examples/Objective-C/Base.lproj/Main.storyboard
@@ -74,25 +74,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="cjF-B5-X6p" style="IBUITableViewCellStyleDefault" id="bgu-qA-Ow2">
-                                        <rect key="frame" x="0.0" y="179.5" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bgu-qA-Ow2" id="9sL-dT-pXS">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Track order" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="cjF-B5-X6p">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="5Fr-Ga-rrl" style="IBUITableViewCellStyleDefault" id="ojm-8m-XYn">
-                                        <rect key="frame" x="0.0" y="223.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="179.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ojm-8m-XYn" id="7Wi-Te-H4j">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -109,7 +92,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="4pW-L9-ISv" style="IBUITableViewCellStyleDefault" id="LrZ-GG-Cy0">
-                                        <rect key="frame" x="0.0" y="267.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="223.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LrZ-GG-Cy0" id="3hF-9A-jN0">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -139,7 +122,6 @@
                         <outlet property="clearAllDataCell" destination="LrZ-GG-Cy0" id="dpv-pr-pB8"/>
                         <outlet property="reportOrderCell" destination="ojm-8m-XYn" id="MLa-uY-nKc"/>
                         <outlet property="trackIncomingURLCell" destination="I3a-k5-m3p" id="nCb-6u-xO8"/>
-                        <outlet property="trackOrderCell" destination="bgu-qA-Ow2" id="HVa-B3-Hs7"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RAP-Qh-imc" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -32,7 +32,6 @@
 
 @property (weak, nonatomic) IBOutlet UITableViewCell *attributionTokenCell;
 @property (weak, nonatomic) IBOutlet UITableViewCell *trackIncomingURLCell;
-@property (weak, nonatomic) IBOutlet UITableViewCell *trackOrderCell;
 @property (weak, nonatomic) IBOutlet UITableViewCell *reportOrderCell;
 @property (weak, nonatomic) IBOutlet UITableViewCell *clearAllDataCell;
 
@@ -70,9 +69,6 @@
     if (cell == _trackIncomingURLCell) {
         [self trackIncomingURL];
     }
-    else if (cell == _trackOrderCell) {
-        [self trackOrder];
-    }
     else if (cell == _reportOrderCell) {
         [self reportOrder];
     }
@@ -91,18 +87,15 @@
 }
 
 
-- (void)trackOrder {
-    Order *order = [[Order alloc] initWithId:NSUUID.UUID.UUIDString
-                                      amount:arc4random_uniform(1000)
-                                currencyCode:@"USD"];
-    [ButtonMerchant trackOrder:order completion:NULL];
-}
-
-
 - (void)reportOrder {
-    LineItem *lineitem = [[LineItem alloc] initWithIdentifier:NSUUID.UUID.UUIDString total:arc4random_uniform(1000)];
+    NSString *id = NSUUID.UUID.UUIDString;
+    LineItem *lineitem = [[LineItem alloc] initWithIdentifier:id total:arc4random_uniform(1000)];
     Order *order = [[Order alloc] initWithId:NSUUID.UUID.UUIDString purchaseDate:[NSDate date] lineItems: @[lineitem]];
-    [ButtonMerchant reportOrder:order completion:NULL];
+    [ButtonMerchant reportOrder:order completion:^(NSError * _Nullable error) {
+        dispatch_async(dispatch_get_main_queue(), ^(){
+            [MessageView showWithTitle:@"Order Created" body:[NSString stringWithFormat:@"Id: %@", id] in:self.navigationController.view];
+        });
+    }];
 }
 
 

--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -33,6 +33,7 @@
 @property (weak, nonatomic) IBOutlet UITableViewCell *attributionTokenCell;
 @property (weak, nonatomic) IBOutlet UITableViewCell *trackIncomingURLCell;
 @property (weak, nonatomic) IBOutlet UITableViewCell *trackOrderCell;
+@property (weak, nonatomic) IBOutlet UITableViewCell *reportOrderCell;
 @property (weak, nonatomic) IBOutlet UITableViewCell *clearAllDataCell;
 
 @end
@@ -72,6 +73,9 @@
     else if (cell == _trackOrderCell) {
         [self trackOrder];
     }
+    else if (cell == _reportOrderCell) {
+        [self reportOrder];
+    }
     else if (cell == _clearAllDataCell) {
         [self clearAllData];
     }
@@ -92,6 +96,13 @@
                                       amount:arc4random_uniform(1000)
                                 currencyCode:@"USD"];
     [ButtonMerchant trackOrder:order completion:NULL];
+}
+
+
+- (void)reportOrder {
+    LineItem *lineitem = [[LineItem alloc] initWithIdentifier:NSUUID.UUID.UUIDString total:arc4random_uniform(1000)];
+    Order *order = [[Order alloc] initWithId:NSUUID.UUID.UUIDString purchaseDate:[NSDate date] lineItems: @[lineitem]];
+    [ButtonMerchant reportOrder:order completion:NULL];
 }
 
 

--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -90,7 +90,9 @@
 - (void)reportOrder {
     NSString *id = NSUUID.UUID.UUIDString;
     LineItem *lineitem = [[LineItem alloc] initWithIdentifier:id total:arc4random_uniform(1000)];
+    Customer *customer = [[Customer alloc] initWithId:NSUUID.UUID.UUIDString];
     Order *order = [[Order alloc] initWithId:NSUUID.UUID.UUIDString purchaseDate:[NSDate date] lineItems: @[lineitem]];
+    order.customer = customer;
     [ButtonMerchant reportOrder:order completion:^(NSError * _Nullable error) {
         dispatch_async(dispatch_get_main_queue(), ^(){
             [MessageView showWithTitle:@"Order Created" body:[NSString stringWithFormat:@"Id: %@", id] in:self.navigationController.view];

--- a/Examples/Swift/Base.lproj/Main.storyboard
+++ b/Examples/Swift/Base.lproj/Main.storyboard
@@ -74,25 +74,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="RdR-1O-DfS" style="IBUITableViewCellStyleDefault" id="Z22-BK-Xgp">
-                                        <rect key="frame" x="0.0" y="179.5" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Z22-BK-Xgp" id="wjZ-YN-IrY">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Track order" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="RdR-1O-DfS">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="tDQ-kV-9ZW" style="IBUITableViewCellStyleDefault" id="vAf-e0-0WA">
-                                        <rect key="frame" x="0.0" y="223.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="179.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vAf-e0-0WA" id="clo-Jb-LJG">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -109,7 +92,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="tkr-SY-yfY" style="IBUITableViewCellStyleDefault" id="J8m-FK-GmU">
-                                        <rect key="frame" x="0.0" y="267.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="223.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="J8m-FK-GmU" id="Lut-6e-qwT">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -139,7 +122,6 @@
                         <outlet property="clearAllDataCell" destination="J8m-FK-GmU" id="N5p-19-m8L"/>
                         <outlet property="reportOrderCell" destination="vAf-e0-0WA" id="JrT-Rn-K1X"/>
                         <outlet property="trackIncomingURLCell" destination="h6B-es-1Cs" id="njy-JH-FMu"/>
-                        <outlet property="trackOrderCell" destination="Z22-BK-Xgp" id="HJG-ct-s3N"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qur-dv-1uE" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Examples/Swift/Base.lproj/Main.storyboard
+++ b/Examples/Swift/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ux9-P5-4ZY">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ux9-P5-4ZY">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -91,8 +91,25 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="tkr-SY-yfY" style="IBUITableViewCellStyleDefault" id="J8m-FK-GmU">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="tDQ-kV-9ZW" style="IBUITableViewCellStyleDefault" id="vAf-e0-0WA">
                                         <rect key="frame" x="0.0" y="223.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vAf-e0-0WA" id="clo-Jb-LJG">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Report order" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tDQ-kV-9ZW">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="tkr-SY-yfY" style="IBUITableViewCellStyleDefault" id="J8m-FK-GmU">
+                                        <rect key="frame" x="0.0" y="267.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="J8m-FK-GmU" id="Lut-6e-qwT">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -120,6 +137,7 @@
                     <connections>
                         <outlet property="attributionTokenCell" destination="vR7-04-fgy" id="lhh-Xh-NWh"/>
                         <outlet property="clearAllDataCell" destination="J8m-FK-GmU" id="N5p-19-m8L"/>
+                        <outlet property="reportOrderCell" destination="vAf-e0-0WA" id="JrT-Rn-K1X"/>
                         <outlet property="trackIncomingURLCell" destination="h6B-es-1Cs" id="njy-JH-FMu"/>
                         <outlet property="trackOrderCell" destination="Z22-BK-Xgp" id="HJG-ct-s3N"/>
                     </connections>

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -80,9 +80,11 @@ class ViewController: UITableViewController {
 
     func reportOrder() {
         let id = NSUUID().uuidString
+        let customer = Order.Customer(id: NSUUID().uuidString)
         let order = Order(id: id,
                           purchaseDate: Date(),
                           lineItems: [Order.LineItem(identifier: NSUUID().uuidString, total: Int64(arc4random_uniform(1000)))])
+        order.customer = customer
         ButtonMerchant.reportOrder(order) { (error) in
             DispatchQueue.main.async {
                 MessageView.showWithTitle("Order Created", body: "Id: \(id)", in: self.navigationController!.view)

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -30,6 +30,7 @@ class ViewController: UITableViewController {
     @IBOutlet weak var attributionTokenCell: UITableViewCell!
     @IBOutlet weak var trackIncomingURLCell: UITableViewCell!
     @IBOutlet weak var trackOrderCell: UITableViewCell!
+    @IBOutlet weak var reportOrderCell: UITableViewCell!
     @IBOutlet weak var clearAllDataCell: UITableViewCell!
     
     var attributionTokenString: String? {
@@ -64,6 +65,8 @@ class ViewController: UITableViewController {
             trackIncomingURL()
         case trackOrderCell:
             trackOrder()
+        case reportOrderCell:
+            reportOrder()
         case clearAllDataCell:
             clearAllData()
         default: break
@@ -82,6 +85,13 @@ class ViewController: UITableViewController {
         let amount = arc4random_uniform(1000)
         let order = Order(id: NSUUID().uuidString, amount: Int64(amount))
         ButtonMerchant.trackOrder(order)
+    }
+    
+    func reportOrder() {
+        let order = Order(id: NSUUID().uuidString,
+                          purchaseDate: Date(),
+                          lineItems: [Order.LineItem(identifier: NSUUID().uuidString, total: Int64(arc4random_uniform(1000)))])
+        ButtonMerchant.reportOrder(order)
     }
 
     func clearAllData() {

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -29,7 +29,6 @@ class ViewController: UITableViewController {
 
     @IBOutlet weak var attributionTokenCell: UITableViewCell!
     @IBOutlet weak var trackIncomingURLCell: UITableViewCell!
-    @IBOutlet weak var trackOrderCell: UITableViewCell!
     @IBOutlet weak var reportOrderCell: UITableViewCell!
     @IBOutlet weak var clearAllDataCell: UITableViewCell!
     
@@ -63,8 +62,6 @@ class ViewController: UITableViewController {
         switch cell {
         case trackIncomingURLCell:
             trackIncomingURL()
-        case trackOrderCell:
-            trackOrder()
         case reportOrderCell:
             reportOrder()
         case clearAllDataCell:
@@ -81,17 +78,16 @@ class ViewController: UITableViewController {
         UIApplication.shared.openURL(URL(string: "merchant-demo:///?btn_ref=srctok-test\(n)")!)
     }
 
-    func trackOrder() {
-        let amount = arc4random_uniform(1000)
-        let order = Order(id: NSUUID().uuidString, amount: Int64(amount))
-        ButtonMerchant.trackOrder(order)
-    }
-    
     func reportOrder() {
-        let order = Order(id: NSUUID().uuidString,
+        let id = NSUUID().uuidString
+        let order = Order(id: id,
                           purchaseDate: Date(),
                           lineItems: [Order.LineItem(identifier: NSUUID().uuidString, total: Int64(arc4random_uniform(1000)))])
-        ButtonMerchant.reportOrder(order)
+        ButtonMerchant.reportOrder(order) { (error) in
+            DispatchQueue.main.async {
+                MessageView.showWithTitle("Order Created", body: "Id: \(id)", in: self.navigationController!.view)
+            }
+        }
     }
 
     func clearAllData() {


### PR DESCRIPTION
### Goals :dart:
Add UI for report order example in the example app.

### Implementation Details :construction:
* Added report order cell to the table view in the storyboards.
* Added `reportOrder` method in the `ViewController`.

 <img src="https://user-images.githubusercontent.com/28634279/60347593-b94f5a00-998b-11e9-9d42-b8bc1e4e9318.png" height="649" width="300">

