### PR TITLE
Allow merchants to disable including IFA via features

### DIFF
--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		DA98C00622B29BA0002D1823 /* PEMCertificate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA98C00522B29BA0002D1823 /* PEMCertificate.swift */; };
 		DADE90C2209B9A630073144B /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADE90C1209B9A630073144B /* TestError.swift */; };
 		DAE8B96F22AF5F0700D11AF9 /* TrustEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */; };
+		DC1F008122CA85F000E789D0 /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1F008022CA85F000E789D0 /* Configurable.swift */; };
 		DC4AAD4422B13CD3005CE460 /* OrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4AAD4322B13CD3005CE460 /* OrderTests.swift */; };
 		DCF4AD0422B421FB000DA3B2 /* ReportOrderBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4AD0322B421FB000DA3B2 /* ReportOrderBody.swift */; };
 		DCF4AD0722B7E31C000DA3B2 /* ReportOrderBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4AD0522B7E2FF000DA3B2 /* ReportOrderBodyTests.swift */; };
@@ -214,6 +215,7 @@
 		DA98C00522B29BA0002D1823 /* PEMCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PEMCertificate.swift; sourceTree = "<group>"; };
 		DADE90C1209B9A630073144B /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrustEvaluator.swift; sourceTree = "<group>"; };
+		DC1F008022CA85F000E789D0 /* Configurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurable.swift; sourceTree = "<group>"; };
 		DC4AAD4322B13CD3005CE460 /* OrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTests.swift; sourceTree = "<group>"; };
 		DCF4AD0322B421FB000DA3B2 /* ReportOrderBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportOrderBody.swift; sourceTree = "<group>"; };
 		DCF4AD0522B7E2FF000DA3B2 /* ReportOrderBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportOrderBodyTests.swift; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 			children = (
 				DE175A1920A09BB1005C97B9 /* Version */,
 				DE865F792052F90600F4054D /* ButtonMerchant.swift */,
+				DC1F008022CA85F000E789D0 /* Configurable.swift */,
 				DCF4AD0322B421FB000DA3B2 /* ReportOrderBody.swift */,
 				DA0FA29F205C1B3A008296A6 /* Core.swift */,
 				9E77202120605506005F740B /* ButtonDefaults.swift */,
@@ -1122,6 +1125,7 @@
 				9EFF2B5A2065965000250269 /* UserDefaultsExtensions.swift in Sources */,
 				9E2B4314206C12BC009F2886 /* URLSessionDataTaskExtensions.swift in Sources */,
 				DA0FA2A0205C1B3A008296A6 /* Core.swift in Sources */,
+				DC1F008122CA85F000E789D0 /* Configurable.swift in Sources */,
 				DE95967E20856626004BC9EA /* ASIdentifierManagerExtensions.swift in Sources */,
 				DA4AF059208699CA002C3E0E /* NotificationExtensions.swift in Sources */,
 				9E976B87207D1A3000783F1A /* DateExtensions.swift in Sources */,

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -32,7 +32,12 @@ import AdSupport
  get your application Id from from the [Button Dashboard](https://app.usebutton.com).
  and follow our simple [integration guide](https://developer.usebutton.com/guides/merchants/ios/open-source-merchant-library)
  */
+@objcMembers
 final public class ButtonMerchant: NSObject {
+    
+    public static var features: Configurable {
+        return core.system
+    }
     
     // swiftlint:disable:next identifier_name
     internal static var _core: CoreType?

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -35,10 +35,6 @@ import AdSupport
 @objcMembers
 final public class ButtonMerchant: NSObject {
     
-    public static var features: Configurable {
-        return core.system
-    }
-    
     // swiftlint:disable:next identifier_name
     internal static var _core: CoreType?
     private static var core: CoreType {
@@ -137,7 +133,14 @@ final public class ButtonMerchant: NSObject {
     @objc public static func handlePostInstallURL(_ completion: @escaping (URL?, Error?) -> Void) {
         core.handlePostInstallURL(completion)
     }
-
+    
+    /**
+     Button ML features configuration.
+     */
+    public static var features: Configurable {
+        return core.system
+    }
+    
     /**
      Tracks an order.
 

--- a/Source/Configurable.swift
+++ b/Source/Configurable.swift
@@ -1,0 +1,29 @@
+//
+// Config.swift
+//
+// Copyright © 2019 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+public protocol Configurable: class {
+    var includesIFA: Bool { get set }
+}

--- a/Source/Configurable.swift
+++ b/Source/Configurable.swift
@@ -24,6 +24,9 @@
 
 import Foundation
 
+/**
+ Protocol that handles the features property,
+ */
 public protocol Configurable: class {
     var includesIFA: Bool { get set }
 }

--- a/Source/System.swift
+++ b/Source/System.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-internal protocol SystemType: class {
+internal protocol SystemType: Configurable {
     var fileManager: FileManagerType { get }
     var calendar: CalendarType { get }
     var adIdManager: ASIdentifierManagerType { get }
@@ -44,7 +44,8 @@ internal protocol SystemType: class {
 }
 
 internal final class System: SystemType {
-
+    
+    var includesIFA: Bool
     var fileManager: FileManagerType
     var calendar: CalendarType
     var adIdManager: ASIdentifierManagerType
@@ -82,5 +83,6 @@ internal final class System: SystemType {
         self.screen = screen
         self.locale = locale
         self.bundle = bundle
+        self.includesIFA = true
     }
 }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -182,4 +182,20 @@ class ButtonMerchantTests: XCTestCase {
         // Assert
         XCTAssertEqual(testCore.testOrder, expectedOrder)
     }
+    
+    func testIFASet() {
+        // Arrange
+        let testSystem = TestSystem()
+        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                                client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
+                                system: testSystem,
+                                notificationCenter: TestNotificationCenter())
+        
+        // Act
+        ButtonMerchant._core = testCore
+        ButtonMerchant.features.includesIFA = false
+        
+        // Assert
+        XCTAssertFalse(ButtonMerchant.features.includesIFA)
+    }
 }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -183,7 +183,7 @@ class ButtonMerchantTests: XCTestCase {
         XCTAssertEqual(testCore.testOrder, expectedOrder)
     }
     
-    func testIFASet() {
+    func testIFASetFalse() {
         // Arrange
         let testSystem = TestSystem()
         let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
@@ -197,5 +197,21 @@ class ButtonMerchantTests: XCTestCase {
         
         // Assert
         XCTAssertFalse(ButtonMerchant.features.includesIFA)
+    }
+    
+    func testIFASetTrue() {
+        // Arrange
+        let testSystem = TestSystem()
+        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                                client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
+                                system: testSystem,
+                                notificationCenter: TestNotificationCenter())
+        
+        // Act
+        ButtonMerchant._core = testCore
+        ButtonMerchant.features.includesIFA = true
+        
+        // Assert
+        XCTAssertTrue(ButtonMerchant.features.includesIFA)
     }
 }

--- a/Tests/UnitTests/SystemTests.swift
+++ b/Tests/UnitTests/SystemTests.swift
@@ -143,4 +143,16 @@ class SystemTests: XCTestCase {
         // Assert
         XCTAssertFalse(isNewInstall)
     }
+    
+    func testIFADefaultValue() {
+        let system = System(fileManager: TestFileManager(),
+                            calendar: TestCalendar(),
+                            adIdManager: TestAdIdManager(),
+                            device: TestDevice(),
+                            screen: TestScreen(),
+                            locale: TestLocale(),
+                            bundle: TestBundle())
+        
+        XCTAssertTrue(system.includesIFA)
+    }
 }

--- a/Tests/UnitTests/TestObjects/TestSystem.swift
+++ b/Tests/UnitTests/TestObjects/TestSystem.swift
@@ -27,6 +27,7 @@ import UIKit
 
 final class TestSystem: SystemType {
 
+    var includesIFA = true
     //Test Properties
     var testIsNewInstall = false
     var testCurrentDate: Date


### PR DESCRIPTION
### Goals :dart:
Allow merchants to enable including IFA.

### Implementation Details :construction:
* Added `Configurable` protocol
* Added `features` property to `ButtonMerchant`

### Testing Details :mag:
* Added additional unit test for IFA

