### PR TITLE
Allow toggling IFA tracking for order reporting and post install requests

### DIFF
--- a/Source/PostInstallBody.swift
+++ b/Source/PostInstallBody.swift
@@ -27,21 +27,18 @@ import Foundation
 internal struct PostInstallBody: Codable {
 
     let applicationId: String
-    let ifa: String
-    let ifaLimited: Bool
+    let ifa: String?
     let signals: Signals
 
     enum CodingKeys: String, CodingKey {
         case applicationId = "application_id"
         case ifa
-        case ifaLimited = "ifa_limited"
         case signals
     }
 
     init(system: SystemType, applicationId: String) {
         self.applicationId = applicationId
-        ifa = system.adIdManager.advertisingIdentifier.uuidString
-        ifaLimited = !system.adIdManager.isAdvertisingTrackingEnabled
+        ifa = system.advertisingId
         signals = Signals(system: system)
     }
 

--- a/Source/ReportOrderBody.swift
+++ b/Source/ReportOrderBody.swift
@@ -33,6 +33,7 @@ internal struct ReportOrderBody: Codable {
     let customerOrderId: String?
     let lineItems: [Order.LineItem]?
     let customer: Order.Customer?
+    let advertisingId: String?
     
     enum CodingKeys: String, CodingKey {
         case attributionToken = "btn_ref"
@@ -42,6 +43,7 @@ internal struct ReportOrderBody: Codable {
         case customerOrderId = "customer_order_id"
         case lineItems = "line_items"
         case customer
+        case advertisingId = "advertising_id"
     }
     
     init(system: SystemType,
@@ -56,6 +58,7 @@ internal struct ReportOrderBody: Codable {
         self.customerOrderId = order.customerOrderId
         self.lineItems = order.lineItems
         self.customer = order.customer
+        self.advertisingId = system.advertisingId
     }
 
 }

--- a/Source/System.swift
+++ b/Source/System.swift
@@ -27,7 +27,7 @@ import UIKit
 internal protocol SystemType: Configurable {
     var fileManager: FileManagerType { get }
     var calendar: CalendarType { get }
-    var adIdManager: ASIdentifierManagerType { get }
+    var advertisingId: String? { get }
     var device: UIDeviceType { get }
     var screen: UIScreenType { get }
     var locale: LocaleType { get }
@@ -45,15 +45,24 @@ internal protocol SystemType: Configurable {
 
 internal final class System: SystemType {
     
+    private var adIdManager: ASIdentifierManagerType
+    
     var includesIFA: Bool
     var fileManager: FileManagerType
     var calendar: CalendarType
-    var adIdManager: ASIdentifierManagerType
     var device: UIDeviceType
     var screen: UIScreenType
     var locale: LocaleType
     var bundle: BundleType
 
+    var advertisingId: String? {
+        if self.includesIFA && self.adIdManager.isAdvertisingTrackingEnabled {
+            return self.adIdManager.advertisingIdentifier.uuidString
+        } else {
+            return nil
+        }
+    }
+    
     var currentDate: Date {
         return Date()
     }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -197,7 +197,6 @@ class ButtonMerchantTests: XCTestCase {
         
         // Assert
         XCTAssertFalse(ButtonMerchant.features.includesIFA)
-        XCTAssertNil(testCore.system.advertisingId)
     }
     
     func testIFASetTrue() {
@@ -214,6 +213,5 @@ class ButtonMerchantTests: XCTestCase {
         
         // Assert
         XCTAssertTrue(ButtonMerchant.features.includesIFA)
-        XCTAssertEqual(testCore.system.advertisingId!, "00000000-0000-0000-0000-000000000000")
     }
 }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -197,6 +197,7 @@ class ButtonMerchantTests: XCTestCase {
         
         // Assert
         XCTAssertFalse(ButtonMerchant.features.includesIFA)
+        XCTAssertNil(testCore.system.advertisingId)
     }
     
     func testIFASetTrue() {
@@ -213,5 +214,6 @@ class ButtonMerchantTests: XCTestCase {
         
         // Assert
         XCTAssertTrue(ButtonMerchant.features.includesIFA)
+        XCTAssertEqual(testCore.system.advertisingId!, "00000000-0000-0000-0000-000000000000")
     }
 }

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -208,7 +208,6 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.testParameters as NSDictionary,
                        ["application_id": "app-123",
                         "ifa": "00000000-0000-0000-0000-000000000000",
-                        "ifa_limited": false,
                         "signals":
                             ["source": "button-merchant",
                              "os": "ios",
@@ -407,7 +406,8 @@ class CoreTests: XCTestCase {
         }
 
         XCTAssertEqual(testClient.testParameters as NSDictionary,
-                       ["btn_ref": "srctok-abc123",
+                       ["advertising_id": "00000000-0000-0000-0000-000000000000",
+                        "btn_ref": "srctok-abc123",
                         "order_id": "order-abc",
                         "currency": "USD",
                         "purchase_date": date.ISO8601String,
@@ -450,7 +450,8 @@ class CoreTests: XCTestCase {
         }
 
         XCTAssertEqual(testClient.testParameters as NSDictionary,
-                       ["order_id": "order-abc",
+                       ["advertising_id": "00000000-0000-0000-0000-000000000000",
+                        "order_id": "order-abc",
                         "currency": "USD",
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",

--- a/Tests/UnitTests/PostInstallBodyTests.swift
+++ b/Tests/UnitTests/PostInstallBodyTests.swift
@@ -70,4 +70,35 @@ class PostInstallBodyTests: XCTestCase {
                                     "language": "en",
                                     "screen": "1080x1920"]])
     }
+    
+    func testDisableIFA() {
+        let testSystem = TestSystem()
+        testSystem.advertisingId = nil
+        let body = PostInstallBody(system: testSystem, applicationId: "app-abc123")
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       ["application_id": "app-abc123",
+                        "signals": ["source": "button-merchant",
+                                    "os": "ios",
+                                    "os_version": "11.0",
+                                    "device": "iPhone",
+                                    "country": "US",
+                                    "language": "en",
+                                    "screen": "1080x1920"]])
+    }
+    
+    func testEnableIFA() {
+        let testSystem = TestSystem()
+        testSystem.advertisingId = "123456008-1234-1234-1234-123456789000"
+        let body = PostInstallBody(system: testSystem, applicationId: "app-abc123")
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       ["application_id": "app-abc123",
+                        "ifa": "123456008-1234-1234-1234-123456789000",
+                        "signals": ["source": "button-merchant",
+                                    "os": "ios",
+                                    "os_version": "11.0",
+                                    "device": "iPhone",
+                                    "country": "US",
+                                    "language": "en",
+                                    "screen": "1080x1920"]])
+    }
 }

--- a/Tests/UnitTests/PostInstallBodyTests.swift
+++ b/Tests/UnitTests/PostInstallBodyTests.swift
@@ -35,7 +35,6 @@ class PostInstallBodyTests: XCTestCase {
         let body = PostInstallBody(system: TestSystem(), applicationId: "app-abc123")
         XCTAssertEqual(body.applicationId, "app-abc123")
         XCTAssertEqual(body.ifa, "00000000-0000-0000-0000-000000000000")
-        XCTAssertFalse(body.ifaLimited)
         XCTAssertEqual(body.signals.source, "button-merchant")
         XCTAssertEqual(body.signals.os, "ios")
         XCTAssertEqual(body.signals.osVersion, "11.0")
@@ -63,7 +62,6 @@ class PostInstallBodyTests: XCTestCase {
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
                        ["application_id": "app-abc123",
                         "ifa": "00000000-0000-0000-0000-000000000000",
-                        "ifa_limited": false,
                         "signals": ["source": "button-merchant",
                                     "os": "ios",
                                     "os_version": "11.0",

--- a/Tests/UnitTests/ReportOrderBodyTests.swift
+++ b/Tests/UnitTests/ReportOrderBodyTests.swift
@@ -71,7 +71,8 @@ class ReportOrderBodyTests: XCTestCase {
         
         // Assert
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
-                       ["btn_ref": "srctok-abc123",
+                       ["advertising_id": "00000000-0000-0000-0000-000000000000",
+                        "btn_ref": "srctok-abc123",
                         "order_id": "order-abc",
                         "currency": "USD",
                         "purchase_date": date.ISO8601String,

--- a/Tests/UnitTests/ReportOrderBodyTests.swift
+++ b/Tests/UnitTests/ReportOrderBodyTests.swift
@@ -81,4 +81,25 @@ class ReportOrderBodyTests: XCTestCase {
                         "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
     }
     
+    func testAdvertisingIdSetToNil() {
+        // Arrange
+        Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
+        let date: Date = Date.ISO8601Formatter.date(from: "2019-06-17T12:08:10-04:00")!
+        let order = Order(id: "order-abc", purchaseDate: date, lineItems: [])
+        let testSystem = TestSystem()
+        testSystem.advertisingId = nil
+        // Act
+        let body = ReportOrderBody(system: testSystem,
+                                   applicationId: "app-abc123",
+                                   attributionToken: "srctok-abc123",
+                                   order: order)
+        
+        // Assert
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       ["btn_ref": "srctok-abc123",
+                        "order_id": "order-abc",
+                        "currency": "USD",
+                        "purchase_date": date.ISO8601String,
+                        "line_items": []])
+    }
 }

--- a/Tests/UnitTests/SystemTests.swift
+++ b/Tests/UnitTests/SystemTests.swift
@@ -166,4 +166,39 @@ class SystemTests: XCTestCase {
         
         XCTAssertEqual(system.advertisingId, "00000000-0000-0000-0000-000000000000")
     }
+    
+    func testAdManagerTrackingSetToFalse() {
+        // Arrange
+        let adManager = TestAdIdManager()
+        adManager.isAdvertisingTrackingEnabled = false
+        
+        // Act
+        let system = System(fileManager: TestFileManager(),
+                            calendar: TestCalendar(),
+                            adIdManager: adManager,
+                            device: TestDevice(),
+                            screen: TestScreen(),
+                            locale: TestLocale(),
+                            bundle: TestBundle())
+        
+        // Assert
+        XCTAssertNil(system.advertisingId)
+    }
+    
+    func testincludesIFASetToFalse() {
+        // Arrange
+        let system = System(fileManager: TestFileManager(),
+                            calendar: TestCalendar(),
+                            adIdManager: TestAdIdManager(),
+                            device: TestDevice(),
+                            screen: TestScreen(),
+                            locale: TestLocale(),
+                            bundle: TestBundle())
+        
+        // Act
+        system.includesIFA = false
+        
+        // Assert
+        XCTAssertNil(system.advertisingId)
+    }
 }

--- a/Tests/UnitTests/SystemTests.swift
+++ b/Tests/UnitTests/SystemTests.swift
@@ -44,7 +44,7 @@ class SystemTests: XCTestCase {
                              bundle: bundle)
         XCTAssertEqualReferences(system.fileManager, fileManager)
         XCTAssertEqualReferences(system.calendar as AnyObject, calendar)
-        XCTAssertEqualReferences(system.adIdManager, adIdManager)
+        //XCTAssertEqualReferences(system.adIdManager, adIdManager)
         XCTAssertEqualReferences(system.device, device)
         XCTAssertEqualReferences(system.screen, screen)
         XCTAssertEqualReferences(system.locale as AnyObject, locale)
@@ -154,5 +154,17 @@ class SystemTests: XCTestCase {
                             bundle: TestBundle())
         
         XCTAssertTrue(system.includesIFA)
+    }
+    
+    func testAdvertisingIdInitialization() {
+        let system = System(fileManager: TestFileManager(),
+                            calendar: TestCalendar(),
+                            adIdManager: TestAdIdManager(),
+                            device: TestDevice(),
+                            screen: TestScreen(),
+                            locale: TestLocale(),
+                            bundle: TestBundle())
+        
+        XCTAssertEqual(system.advertisingId, "00000000-0000-0000-0000-000000000000")
     }
 }

--- a/Tests/UnitTests/SystemTests.swift
+++ b/Tests/UnitTests/SystemTests.swift
@@ -44,7 +44,6 @@ class SystemTests: XCTestCase {
                              bundle: bundle)
         XCTAssertEqualReferences(system.fileManager, fileManager)
         XCTAssertEqualReferences(system.calendar as AnyObject, calendar)
-        //XCTAssertEqualReferences(system.adIdManager, adIdManager)
         XCTAssertEqualReferences(system.device, device)
         XCTAssertEqualReferences(system.screen, screen)
         XCTAssertEqualReferences(system.locale as AnyObject, locale)

--- a/Tests/UnitTests/TestObjects/Foundation/TestAdIdManager.swift
+++ b/Tests/UnitTests/TestObjects/Foundation/TestAdIdManager.swift
@@ -31,7 +31,5 @@ class TestAdIdManager: ASIdentifierManagerType {
         return UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
     }
 
-    var isAdvertisingTrackingEnabled: Bool {
-        return true
-    }
+    var isAdvertisingTrackingEnabled: Bool = true
 }

--- a/Tests/UnitTests/TestObjects/TestSystem.swift
+++ b/Tests/UnitTests/TestObjects/TestSystem.swift
@@ -43,13 +43,7 @@ final class TestSystem: SystemType {
     var locale: LocaleType
     var bundle: BundleType
     
-    var advertisingId: String? {
-        if self.includesIFA && self.adIdManager.isAdvertisingTrackingEnabled {
-            return self.adIdManager.advertisingIdentifier.uuidString
-        } else {
-            return nil
-        }
-    }
+    var advertisingId: String? = TestAdIdManager().advertisingIdentifier.uuidString
     
     var currentDate: Date {
         return testCurrentDate

--- a/Tests/UnitTests/TestObjects/TestSystem.swift
+++ b/Tests/UnitTests/TestObjects/TestSystem.swift
@@ -43,7 +43,7 @@ final class TestSystem: SystemType {
     var locale: LocaleType
     var bundle: BundleType
     
-    var advertisingId: String? = TestAdIdManager().advertisingIdentifier.uuidString
+    var advertisingId: String? = "00000000-0000-0000-0000-000000000000"
     
     var currentDate: Date {
         return testCurrentDate

--- a/Tests/UnitTests/TestObjects/TestSystem.swift
+++ b/Tests/UnitTests/TestObjects/TestSystem.swift
@@ -26,8 +26,10 @@ import UIKit
 @testable import ButtonMerchant
 
 final class TestSystem: SystemType {
+    
+    private var adIdManager: ASIdentifierManagerType
 
-    var includesIFA = true
+    var includesIFA: Bool
     //Test Properties
     var testIsNewInstall = false
     var testCurrentDate: Date
@@ -36,12 +38,19 @@ final class TestSystem: SystemType {
     // SystemType
     var fileManager: FileManagerType
     var calendar: CalendarType
-    var adIdManager: ASIdentifierManagerType
     var device: UIDeviceType
     var screen: UIScreenType
     var locale: LocaleType
     var bundle: BundleType
-
+    
+    var advertisingId: String? {
+        if self.includesIFA && self.adIdManager.isAdvertisingTrackingEnabled {
+            return self.adIdManager.advertisingIdentifier.uuidString
+        } else {
+            return nil
+        }
+    }
+    
     var currentDate: Date {
         return testCurrentDate
     }
@@ -61,7 +70,7 @@ final class TestSystem: SystemType {
         // Fix timezone to UTC for tests.
         Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
         testCurrentDate = Date.ISO8601Formatter.date(from: "2018-01-23T12:00:00Z")!
-
+        
         self.fileManager = fileManager
         self.calendar = calendar
         self.adIdManager = adIdManager
@@ -69,5 +78,6 @@ final class TestSystem: SystemType {
         self.screen = screen
         self.locale = locale
         self.bundle = bundle
+        self.includesIFA = true
     }
 }


### PR DESCRIPTION
### Goals :dart:
Merchants can toggle IFA when reporting an order. Additionally, merchants can toggle IFA for post install requests.

### Implementation Details :construction:
* `ReportOrderBody` now has the `advertisingId` property.
* `PostInstallBody`'s `ifa` property is now optional and is set by `advertisingId`.
* `PostInstallBody`'s `ifaLimited` property is removed.
*  Made `adIdManager` a private property in `System`.
* `advertisingId` only get set when `includesIFA` and `adIdManager.isAdvertisingTrackingEnabled` is true, otherwise it is nil.

### Testing Details :mag:
Updated and addded some unit tests.

