### PR TITLE
Change "contains" to "hasSuffix" when checking pinned certs

### DIFF
--- a/Source/TrustEvaluator.swift
+++ b/Source/TrustEvaluator.swift
@@ -70,7 +70,7 @@ final internal class TrustEvaluator: TrustEvaluatorType {
     private func shouldPinChallenge(_ challenge: URLAuthenticationChallengeType) -> Bool {
         let space = challenge.getProtectionSpace()
         guard space.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-            space.host.contains(".usebutton.com") else {
+            space.host.hasSuffix(".usebutton.com") else {
                 return false
         }
         return true

--- a/Tests/UnitTests/TrustEvaluatorTests.swift
+++ b/Tests/UnitTests/TrustEvaluatorTests.swift
@@ -233,4 +233,36 @@ class TrustEvaluatorTests: XCTestCase {
         }
         wait(for: [exp], timeout: 2.0)
     }
+    
+    func testHandleChallenge_invalidHost_performsDefaultHandling() {
+        // Arrange
+        let exp = expectation(description: "invalid host")
+        let space = TestURLProtectionSpace(host: "derp.usebutton.com.foo.com")
+        let challenge = TestURLAuthenticationChallenge(space)
+        
+        // Act
+        evaluator.handleChallenge(challenge) { disposition, _ in
+            
+            // Assert
+            XCTAssertEqual(disposition, URLSession.AuthChallengeDisposition.performDefaultHandling)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+    }
+    
+    func testHandleChallenge_validHost_performsDefaultHandling() {
+        // Arrange
+        let exp = expectation(description: "valid host")
+        let space = TestURLProtectionSpace(host: "api.usebutton.com")
+        let challenge = TestURLAuthenticationChallenge(space)
+        
+        // Act
+        evaluator.handleChallenge(challenge) { disposition, _ in
+            
+            // Assert
+            XCTAssertEqual(disposition, URLSession.AuthChallengeDisposition.performDefaultHandling)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+    }
 }


### PR DESCRIPTION
### Issue Link :link:
* `space.host.contains(".usebutton.com")` was changed to `space.host.hasSuffix(".usebutton.com")` because ".usebutton.com" must be at the end of a host or else if ".usebutton.com" were to appear anywhere else, it will cause false positives.

### Testing Details :mag:
* Added two unit test in `TrustEvaluatorTests` .

