### PR TITLE
iOS 14 prep: Discard IFAs that are all zeros

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ButtonMerchant.xcworkspace/xcshareddata/xcschemes/Example.xcscheme
+++ b/ButtonMerchant.xcworkspace/xcshareddata/xcschemes/Example.xcscheme
@@ -55,6 +55,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:ButtonMerchant.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -77,17 +86,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
-            BuildableName = "Example.app"
-            BlueprintName = "Example"
-            ReferencedContainer = "container:ButtonMerchant.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -109,8 +107,6 @@
             ReferencedContainer = "container:ButtonMerchant.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/Extensions/ASIdentifierManagerExtensions.swift
+++ b/Source/Extensions/ASIdentifierManagerExtensions.swift
@@ -26,7 +26,6 @@ import AdSupport
 
 internal protocol ASIdentifierManagerType: class {
     var advertisingIdentifier: UUID { get }
-    var isAdvertisingTrackingEnabled: Bool { get }
 }
 
 extension ASIdentifierManager: ASIdentifierManagerType {}

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -56,4 +56,7 @@ public extension String {
         return hexString
     }
 
+    internal func matches(_ regex: String) -> Bool {
+        return self.range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil
+    }
 }

--- a/Source/System.swift
+++ b/Source/System.swift
@@ -45,6 +45,8 @@ internal protocol SystemType: Configurable {
 
 internal final class System: SystemType {
     
+    static let allZerosPattern = "^(?:[0+\\-]+){10,}$"
+    
     private var adIdManager: ASIdentifierManagerType
     
     var includesIFA: Bool
@@ -56,11 +58,11 @@ internal final class System: SystemType {
     var bundle: BundleType
 
     var advertisingId: String? {
-        if self.includesIFA && self.adIdManager.isAdvertisingTrackingEnabled {
-            return self.adIdManager.advertisingIdentifier.uuidString
-        } else {
+        let ifa = self.adIdManager.advertisingIdentifier.uuidString
+        guard self.includesIFA && !ifa.matches(System.allZerosPattern) else {
             return nil
         }
+        return ifa
     }
     
     var currentDate: Date {

--- a/Tests/UnitTests/SystemTests.swift
+++ b/Tests/UnitTests/SystemTests.swift
@@ -155,22 +155,30 @@ class SystemTests: XCTestCase {
         XCTAssertTrue(system.includesIFA)
     }
     
-    func testAdvertisingIdInitialization() {
+    func testAdvertisingId_whenValid_returnsString() {
+        // Arrange
+        let adManager = TestAdIdManager()
         let system = System(fileManager: TestFileManager(),
                             calendar: TestCalendar(),
-                            adIdManager: TestAdIdManager(),
+                            adIdManager: adManager,
                             device: TestDevice(),
                             screen: TestScreen(),
                             locale: TestLocale(),
                             bundle: TestBundle())
         
-        XCTAssertEqual(system.advertisingId, "00000000-0000-0000-0000-000000000000")
+        adManager.stubbedID = .validId
+        XCTAssertEqual(system.advertisingId, "11111111-1111-1111-1111-111111111111")
+        adManager.stubbedID = .validIdWithLeadingZeros
+        XCTAssertEqual(system.advertisingId, "00000000-0011-1111-1111-111111111111")
+        adManager.stubbedID = .validIdWithMidZeros
+        XCTAssertEqual(system.advertisingId, "11111111-1000-0000-0001-111111111111")
+        adManager.stubbedID = .validIdWithTrailingZeros
+        XCTAssertEqual(system.advertisingId, "11111111-1111-1111-1111-110000000000")
     }
     
-    func testAdManagerTrackingSetToFalse() {
+    func testAdvertisingId_whenInvalid_returnsNil() {
         // Arrange
-        let adManager = TestAdIdManager()
-        adManager.isAdvertisingTrackingEnabled = false
+        let adManager = TestAdIdManager(.invalidId)
         
         // Act
         let system = System(fileManager: TestFileManager(),

--- a/Tests/UnitTests/TestObjects/Foundation/TestAdIdManager.swift
+++ b/Tests/UnitTests/TestObjects/Foundation/TestAdIdManager.swift
@@ -26,10 +26,22 @@ import UIKit
 @testable import ButtonMerchant
 
 class TestAdIdManager: ASIdentifierManagerType {
-
+    
+    enum AdIDType: String {
+        case validId = "11111111-1111-1111-1111-111111111111"
+        case validIdWithLeadingZeros = "00000000-0011-1111-1111-111111111111"
+        case validIdWithTrailingZeros = "11111111-1111-1111-1111-110000000000"
+        case validIdWithMidZeros = "11111111-1000-0000-0001-111111111111"
+        case invalidId = "00000000-0000-0000-0000-000000000000"
+    }
+    
+    var stubbedID: AdIDType
+    
     var advertisingIdentifier: UUID {
-        return UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+        return UUID(uuidString: stubbedID.rawValue)!
     }
 
-    var isAdvertisingTrackingEnabled: Bool = true
+    init(_ adIDType: AdIDType = .validId) {
+        stubbedID = adIDType
+    }
 }


### PR DESCRIPTION
### Goals :dart:
- Stop checking `isAdvertisingTrackingEnabled` which will [always return `false` in iOS 14](https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614148-isadvertisingtrackingenabled)
- Check the contents of the IFA and discard any with all zeros

### Testing Details :mag:
- Added some additional tests to ensure leading, trailing, or a large group of zeros does not get discarded

