### PR TITLE
Refresh session ID from Button network requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10.2
+osx_image: xcode11.6
 language: swift
 env:
   - TEST_SUITE=UnitTests COVERAGE='bundle exec fastlane coverage'

--- a/ButtonMerchant.xcworkspace/xcshareddata/xcschemes/ButtonMerchant.xcscheme
+++ b/ButtonMerchant.xcworkspace/xcshareddata/xcschemes/ButtonMerchant.xcscheme
@@ -54,8 +54,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DE865F832052FE5D00F4054D"
+            BuildableName = "ButtonMerchant.framework"
+            BlueprintName = "ButtonMerchant"
+            ReferencedContainer = "container:ButtonMerchant.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -78,17 +87,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DE865F832052FE5D00F4054D"
-            BuildableName = "ButtonMerchant.framework"
-            BlueprintName = "ButtonMerchant"
-            ReferencedContainer = "container:ButtonMerchant.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -109,8 +107,6 @@
             ReferencedContainer = "container:ButtonMerchant.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/ButtonDefaults.swift
+++ b/Source/ButtonDefaults.swift
@@ -26,6 +26,7 @@ import Foundation
 
 internal protocol ButtonDefaultsType: class {
     var userDefaults: UserDefaultsType { get }
+    var sessionId: String? { get set }
     var attributionToken: String? { get set }
     var hasFetchedPostInstallURL: Bool { get set }
     func clearAllData()
@@ -39,6 +40,7 @@ final internal class ButtonDefaults: ButtonDefaultsType {
 
     internal enum Keys: String {
 
+        case sessionId = "session-id"
         case attributonToken = "attribution-token"
         case postInstallFetchStatus = "post-install-fetched"
 
@@ -50,6 +52,16 @@ final internal class ButtonDefaults: ButtonDefaultsType {
     }
 
     private(set) var userDefaults: UserDefaultsType
+    
+    var sessionId: String? {
+        get {
+            return userDefaults.value(forKey: Keys.sessionId.key) as? String
+        }
+        set {
+            userDefaults.setValue(newValue, forKey: Keys.sessionId.key)
+            userDefaults.synchronize()
+        }
+    }
     
     var attributionToken: String? {
         get {

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -173,8 +173,11 @@ final public class ButtonMerchant: NSObject {
                             locale: NSLocale.current,
                             bundle: Bundle.main)
         let session = URLSession(configuration: .default, delegate: SessionDelegate(system: system), delegateQueue: nil)
-        let client = Client(session: session, userAgent: UserAgent(libraryVersion: Version.stringValue, system: system))
-        return Core(buttonDefaults: ButtonDefaults(userDefaults: UserDefaults.button),
+        let buttonDetaults = ButtonDefaults(userDefaults: UserDefaults.button)
+        let client = Client(session: session,
+                            userAgent: UserAgent(libraryVersion: Version.stringValue, system: system),
+                            defaults: buttonDetaults)
+        return Core(buttonDefaults: buttonDetaults,
                     client: client,
                     system: system,
                     notificationCenter: NotificationCenter.default)

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -29,7 +29,7 @@ internal enum Service: String {
     
     case postInstall = "v1/web/deferred-deeplink"
     case activity = "v1/activity/order"
-    case order = "v1/mobile-order"
+    case order = "v1/app/order"
     
     static var baseURL = "https://api.usebutton.com/"
     
@@ -39,6 +39,7 @@ internal enum Service: String {
 }
 
 internal protocol ClientType: class {
+    var applicationId: String? { get set }
     var session: URLSessionType { get }
     var userAgent: UserAgentType { get }
     func fetchPostInstallURL(parameters: [String: Any], _ completion: @escaping (URL?, String?) -> Void)
@@ -48,7 +49,8 @@ internal protocol ClientType: class {
 }
 
 internal final class Client: ClientType {
-
+    
+    var applicationId: String?
     var session: URLSessionType
     var userAgent: UserAgentType
     var defaults: ButtonDefaultsType
@@ -84,8 +86,7 @@ internal final class Client: ClientType {
     }
     
     func reportOrder(orderRequest: ReportOrderRequestType, _ completion: ((Error?) -> Void)?) {
-        var request = urlRequest(url: Service.order.url, parameters: orderRequest.parameters)
-        request.setValue("Basic \(orderRequest.encodedApplicationId)", forHTTPHeaderField: "Authorization")
+        let request = urlRequest(url: Service.order.url, parameters: orderRequest.parameters)
         orderRequest.report(request, with: session, completion)
     }
     
@@ -95,19 +96,21 @@ internal extension Client {
     
     func urlRequest(url: URL, parameters: [String: Any]? = nil) -> URLRequest {
         var urlRequest = URLRequest(url: url)
+        var requestParameters = parameters ?? [:]
+        
         urlRequest.httpMethod = "POST"
         urlRequest.setValue(userAgent.stringRepresentation, forHTTPHeaderField: "User-Agent")
         
-        var requestParameters = parameters
         if let sessionId = defaults.sessionId {
-            requestParameters = requestParameters ?? [:]
-            requestParameters?["session_id"] = sessionId
+            requestParameters["session_id"] = sessionId
         }
         
-        if let parameters = requestParameters {
-            urlRequest.httpBody = try? JSONSerialization.data(withJSONObject: parameters)
-            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let appId = applicationId {
+            requestParameters["application_id"] = appId
         }
+        
+        urlRequest.httpBody = try? JSONSerialization.data(withJSONObject: requestParameters)
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
         return urlRequest
     }

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -130,8 +130,7 @@ internal extension Client {
     func refreshSessionIfAvailable(responseData: Data?) {
         guard let data = responseData,
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let object = json["object"] as? [String: Any],
-            let meta = object["meta"] as? [String: Any] else {
+            let meta = json["meta"] as? [String: Any] else {
                 return
         }
         

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -48,7 +48,11 @@ internal protocol CoreType {
  */
 final internal class Core: CoreType {
 
-    var applicationId: String?
+    var applicationId: String? {
+        didSet {
+            client.applicationId = applicationId
+        }
+    }
     var buttonDefaults: ButtonDefaultsType
     var client: ClientType
     var system: SystemType
@@ -160,8 +164,7 @@ final internal class Core: CoreType {
     }
     
     func reportOrder(_ order: Order, _ completion: ((Error?) -> Void)?) {
-        guard let appId = applicationId, !appId.isEmpty,
-            let encodedAppId = (appId + ":").data(using: .utf8)?.base64EncodedString() else {
+        guard let appId = applicationId, !appId.isEmpty else {
             if let completion = completion {
                 completion(ConfigurationError.noApplicationId)
             }
@@ -169,7 +172,7 @@ final internal class Core: CoreType {
         }
         
         let reportOrderBody = ReportOrderBody(system: system, applicationId: appId, attributionToken: buttonDefaults.attributionToken, order: order)
-        let request = ReportOrderRequest(parameters: reportOrderBody.dictionaryRepresentation, encodedApplicationId: encodedAppId)
+        let request = ReportOrderRequest(parameters: reportOrderBody.dictionaryRepresentation)
         client.reportOrder(orderRequest: request, completion)
     }
 

--- a/Source/ReportOrderRequest.swift
+++ b/Source/ReportOrderRequest.swift
@@ -26,7 +26,6 @@ import Foundation
 
 internal protocol ReportOrderRequestType {
     var parameters: [String: Any] { get }
-    var encodedApplicationId: String { get }
     var retryPolicy: RetryPolicyType { get }
     
     func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Error?) -> Void)?)
@@ -35,12 +34,10 @@ internal protocol ReportOrderRequestType {
 internal final class ReportOrderRequest: ReportOrderRequestType {
     
     var parameters: [String: Any]
-    var encodedApplicationId: String
     var retryPolicy: RetryPolicyType
     
-    required init(parameters: [String: Any], encodedApplicationId: String, retryPolicy: RetryPolicyType = RetryPolicy()) {
+    required init(parameters: [String: Any], retryPolicy: RetryPolicyType = RetryPolicy()) {
         self.parameters = parameters
-        self.encodedApplicationId = encodedApplicationId
         self.retryPolicy = retryPolicy
     }
     

--- a/Tests/UnitTests/ButtonDefaultsTests.swift
+++ b/Tests/UnitTests/ButtonDefaultsTests.swift
@@ -37,6 +37,45 @@ class ButtonDefaultsTests: XCTestCase {
         XCTAssertEqual(ButtonDefaults.Keys.attributonToken.key, "com.usebutton.attribution-token")
     }
     
+    func testSetSessionId_persistsSessionId() {
+        // Arrange
+        let testUserDefaults = TestUserDefaults()
+        let defaults = ButtonDefaults(userDefaults: testUserDefaults)
+        
+        // Act
+        defaults.sessionId = "some-session-id"
+        let actualSessionId = testUserDefaults.values[ButtonDefaults.Keys.sessionId.key]
+        
+        // Assert
+        XCTAssertEqual("some-session-id", actualSessionId as? String)
+    }
+    
+    func testGetSessionId_whenPersisted_returnsStoredSessionId() {
+        // Arrange
+        let testUserDefaults = TestUserDefaults()
+        let defaults = ButtonDefaults(userDefaults: testUserDefaults)
+        
+        // Act
+        testUserDefaults.values[ButtonDefaults.Keys.sessionId.key] = "some-session-id"
+        
+        // Assert
+        XCTAssertEqual(defaults.sessionId, "some-session-id")
+    }
+    
+    func testGetSessionId_whenUnset_returnsNil() {
+        // Arrange
+        let testUserDefaults = TestUserDefaults()
+        let defaults = ButtonDefaults(userDefaults: testUserDefaults)
+        
+        // Act
+        defaults.sessionId = nil
+        let actualSessionId = testUserDefaults.values[ButtonDefaults.Keys.sessionId.key]
+        
+        // Assert
+        XCTAssertNil(actualSessionId)
+        XCTAssertTrue(testUserDefaults.didCallSynchronize)
+    }
+    
     func testSetAttributionTokenPassesTokenToUserDefaultsAndSynchronizes() {
         // Arrange
         let testUserDefaults = TestUserDefaults()
@@ -59,9 +98,10 @@ class ButtonDefaultsTests: XCTestCase {
         
         // Act
         defaults.attributionToken = nil
+        let actualToken = testUserDefaults.values[ButtonDefaults.Keys.attributonToken.key]
         
         //Assert
-        XCTAssertNil(testUserDefaults.testValue)
+        XCTAssertNil(actualToken)
         XCTAssertTrue(testUserDefaults.didCallSynchronize)
     }
     

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -27,6 +27,18 @@ import XCTest
 
 class ButtonMerchantTests: XCTestCase {
 
+    var testCore: TestCore!
+    
+    override func setUp() {
+        let defaults = TestButtonDefaults(userDefaults: TestUserDefaults())
+        testCore = TestCore(buttonDefaults: defaults,
+                            client: TestClient(session: TestURLSession(),
+                                               userAgent: TestUserAgent(system: TestSystem()),
+                                               defaults: defaults),
+                            system: TestSystem(),
+                            notificationCenter: TestNotificationCenter())
+    }
+    
     override func tearDown() {
         super.tearDown()
         ButtonMerchant._core = nil
@@ -39,14 +51,9 @@ class ButtonMerchantTests: XCTestCase {
     func testConfigureApplicationId() {
         // Arrange
         let applicationId = "app-test"
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(),
-                                                   userAgent: TestUserAgent(system: TestSystem())),
-                                system: TestSystem(),
-                                notificationCenter: TestNotificationCenter())
-
-        // Act
         ButtonMerchant._core = testCore
+        
+        // Act
         ButtonMerchant.configure(applicationId: applicationId)
 
         // Assert
@@ -54,22 +61,22 @@ class ButtonMerchantTests: XCTestCase {
     }
 
     func testCreateCoreCreatesCoreWhenCoreSetToNil() {
+        // Arrange
         ButtonMerchant._core = nil
+        
+        // Act
         ButtonMerchant.configure(applicationId: "app-test")
+        
+        // Assert
         XCTAssertTrue(ButtonMerchant._core is Core)
     }
 
     func testTrackIncomingURLInvokesCore() {
         // Arrange
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(),
-                                                   userAgent: TestUserAgent(system: TestSystem())),
-                                system: TestSystem(),
-                                notificationCenter: TestNotificationCenter())
         let expectedUrl = URL(string: "usebutton.com")!
-
-        // Act
         ButtonMerchant._core = testCore
+        
+        // Act
         ButtonMerchant.trackIncomingURL(expectedUrl)
         let actualUrl = testCore.testUrl
 
@@ -79,11 +86,6 @@ class ButtonMerchantTests: XCTestCase {
     
     func testTrackIncomingUserActivityInvokesCore() {
         // Arrange
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(),
-                                                   userAgent: TestUserAgent(system: TestSystem())),
-                                system: TestSystem(),
-                                notificationCenter: TestNotificationCenter())
         let expectedUrl = URL(string: "https://usebutton.com")!
         let userActivity = NSUserActivity(activityType: "com.usebutton.web_activity")
         userActivity.webpageURL = expectedUrl
@@ -99,11 +101,6 @@ class ButtonMerchantTests: XCTestCase {
 
     func testAccessingAttributionToken() {
         // Arrange
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(),
-                                                   userAgent: TestUserAgent(system: TestSystem())),
-                                system: TestSystem(),
-                                notificationCenter: TestNotificationCenter())
         testCore.testToken = "srctok-123"
         let expectedToken = testCore.testToken
 
@@ -117,14 +114,9 @@ class ButtonMerchantTests: XCTestCase {
 
     func testClearAllDataInvokesCore() {
         // Arrange
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(),
-                                                   userAgent: TestUserAgent(system: TestSystem())),
-                                system: TestSystem(),
-                                notificationCenter: TestNotificationCenter())
-
-        // Act
         ButtonMerchant._core = testCore
+        
+        // Act
         ButtonMerchant.clearAllData()
 
         // Assert
@@ -133,31 +125,22 @@ class ButtonMerchantTests: XCTestCase {
 
     func testHandlePostInstallURLInvokesCore() {
         // Arrange
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(),
-                                                   userAgent: TestUserAgent(system: TestSystem())),
-                                system: TestSystem(),
-                                notificationCenter: TestNotificationCenter())
-
-        // Act
         ButtonMerchant._core = testCore
+        
+        // Act
         ButtonMerchant.handlePostInstallURL { _, _  in }
 
+        // Assert
         XCTAssertTrue(testCore.didCallFetchPostInstallURL)
     }
 
     @available(*, deprecated)
     func testTrackOrderInvokesCoreWithOrder() {
         // Arrange
-        let testSystem = TestSystem()
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
-                                system: testSystem,
-                                notificationCenter: TestNotificationCenter())
         let expectedOrder = Order(id: "test", amount: Int64(12))
-
-        // Act
         ButtonMerchant._core = testCore
+        
+        // Act
         ButtonMerchant.trackOrder(expectedOrder) { _ in }
 
         // Assert
@@ -166,17 +149,12 @@ class ButtonMerchantTests: XCTestCase {
     
     func testReportOrderInvokesCoreWithOrder() {
         // Arrange
-        let testSystem = TestSystem()
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
-                                system: testSystem,
-                                notificationCenter: TestNotificationCenter())
         let expectedOrder = Order(id: "test",
                                   purchaseDate: Date(),
                                   lineItems: [Order.LineItem(id: "unique-id-1234", total: 400)])
+        ButtonMerchant._core = testCore
         
         // Act
-        ButtonMerchant._core = testCore
         ButtonMerchant.reportOrder(expectedOrder) { _ in }
         
         // Assert
@@ -185,14 +163,9 @@ class ButtonMerchantTests: XCTestCase {
     
     func testIFASetFalse() {
         // Arrange
-        let testSystem = TestSystem()
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
-                                system: testSystem,
-                                notificationCenter: TestNotificationCenter())
+        ButtonMerchant._core = testCore
         
         // Act
-        ButtonMerchant._core = testCore
         ButtonMerchant.features.includesIFA = false
         
         // Assert
@@ -201,14 +174,9 @@ class ButtonMerchantTests: XCTestCase {
     
     func testIFASetTrue() {
         // Arrange
-        let testSystem = TestSystem()
-        let testCore = TestCore(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                                client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem)),
-                                system: testSystem,
-                                notificationCenter: TestNotificationCenter())
+        ButtonMerchant._core = testCore
         
         // Act
-        ButtonMerchant._core = testCore
         ButtonMerchant.features.includesIFA = true
         
         // Assert

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -157,11 +157,7 @@ class ClientTests: XCTestCase {
         let testURLSession = TestURLSession()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
-        let responseData = try? JSONSerialization.data(withJSONObject:
-            ["object":
-                [ "meta":
-                    ["session_id": "some-session-id"]
-                ]])
+        let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["session_id": "some-session-id"]])
         
         // Act
         let url = URL(string: "https://usebutton.com")!
@@ -187,11 +183,7 @@ class ClientTests: XCTestCase {
         let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
         
         testDefaults.sessionId = "same-old-session"
-        let responseData = try? JSONSerialization.data(withJSONObject:
-            ["object":
-                [ "meta":
-                    ["other": "fields"]
-                ]])
+        let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["other": "fields"] ])
         
         // Act
         let url = URL(string: "https://usebutton.com")!
@@ -217,11 +209,7 @@ class ClientTests: XCTestCase {
         let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
         
         testDefaults.sessionId = "some-old-session"
-        let responseData = try? JSONSerialization.data(withJSONObject:
-            ["object":
-                [ "meta":
-                    ["session_id": "some-new-session"]
-                ]])
+        let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["session_id": "some-new-session"]])
         
         // Act
         let url = URL(string: "https://usebutton.com")!
@@ -246,11 +234,7 @@ class ClientTests: XCTestCase {
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
         
-        let responseData = try? JSONSerialization.data(withJSONObject:
-            ["object":
-                [ "meta":
-                    ["session_id": NSNull()]
-                ]])
+        let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["session_id": NSNull()]])
         
         // Act
         let url = URL(string: "https://usebutton.com")!

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -49,6 +49,20 @@ class CoreTests: XCTestCase {
         XCTAssertEqualReferences(core.notificationCenter, testNotificationCenter)
     }
     
+    func testSetApplicationId_setClientApplicationId() {
+        // Arrange
+        let core = Core(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                        client: testClient,
+                        system: TestSystem(),
+                        notificationCenter: TestNotificationCenter())
+        
+        // Act
+        core.applicationId = "app-abc123"
+        
+        // Assert
+        XCTAssertEqual(testClient.applicationId, "app-abc123")
+    }
+    
     func testTrackIncomingURLIgnoresUnattributedURLs() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
@@ -395,7 +409,6 @@ class CoreTests: XCTestCase {
         core.applicationId = "app-abc123"
         
         // Act
-        // Act
         core.reportOrder(order) { error in
             
             // Assert
@@ -413,7 +426,6 @@ class CoreTests: XCTestCase {
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
                         "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
         
-        XCTAssertEqual(testClient.testReportOrderRequest!.encodedApplicationId, "YXBwLWFiYzEyMzo=")
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -27,10 +27,17 @@ import XCTest
 
 class CoreTests: XCTestCase {
     
+    var testClient: TestClient!
+    
+    override func setUp() {
+        testClient = TestClient(session: TestURLSession(),
+                                userAgent: TestUserAgent(system: TestSystem()),
+                                defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+    }
+    
     func testInitialization() {
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let testNotificationCenter = TestNotificationCenter()
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
@@ -48,7 +55,7 @@ class CoreTests: XCTestCase {
         let testNotificationCenter = TestNotificationCenter()
         let url = URL(string: "http://usebutton.com")!
         let core = Core(buttonDefaults: testDefaults,
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: TestSystem(),
                         notificationCenter: testNotificationCenter)
 
@@ -69,7 +76,7 @@ class CoreTests: XCTestCase {
         let testNotificationCenter = TestNotificationCenter()
         let url = URL(string: "http://usebutton.com/products/listing")!
         let core = Core(buttonDefaults: testDefaults,
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: TestSystem(),
                         notificationCenter: testNotificationCenter)
 
@@ -90,7 +97,7 @@ class CoreTests: XCTestCase {
         let expectedSourceToken = "srctok-123"
         let url = URL(string: "http://usebutton.com/test?btn_ref=\(expectedSourceToken)")!
         let core = Core(buttonDefaults: testDefaults,
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
 
@@ -107,7 +114,7 @@ class CoreTests: XCTestCase {
         let expectedSourceToken = "srctok-123"
         let url = URL(string: "http://usebutton.com/test?btn_ref=\(expectedSourceToken)")!
         let core = Core(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: TestSystem(),
                         notificationCenter: testNotificationCenter)
         
@@ -130,7 +137,7 @@ class CoreTests: XCTestCase {
         let expectedSourceToken = "srctok-321"
         let secondURL = URL(string: "http://usebutton.com/test?btn_ref=\(expectedSourceToken)")!
         let core = Core(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: TestSystem(),
                         notificationCenter: testNotificationCenter)
         
@@ -153,7 +160,7 @@ class CoreTests: XCTestCase {
         let expectedToken = "srctok-123"
         testDefaults.testToken = expectedToken
         let core = Core(buttonDefaults: testDefaults,
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
 
@@ -168,7 +175,7 @@ class CoreTests: XCTestCase {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let core = Core(buttonDefaults: testDefaults,
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
 
@@ -184,7 +191,6 @@ class CoreTests: XCTestCase {
         let expectation = XCTestExpectation(description: "handle post install url")
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -227,7 +233,6 @@ class CoreTests: XCTestCase {
         let expectation = XCTestExpectation(description: "handle post install error")
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -252,7 +257,7 @@ class CoreTests: XCTestCase {
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
         let core = Core(buttonDefaults: testDefaults,
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: testSystem,
                         notificationCenter: TestNotificationCenter())
         testDefaults.testHasFetchedPostInstallURL = false
@@ -270,7 +275,7 @@ class CoreTests: XCTestCase {
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
         let core = Core(buttonDefaults: testDefaults,
-                        client: TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: TestSystem())),
+                        client: testClient,
                         system: testSystem,
                         notificationCenter: TestNotificationCenter())
         testDefaults.testHasFetchedPostInstallURL = false
@@ -288,13 +293,11 @@ class CoreTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "track order")
         let order = Order(id: "order-abc", amount: 120)
-        let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         testDefaults.testToken = "srctok-abc123"
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: testSystem,
+                        system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
         core.applicationId = "app-abc123"
         
@@ -323,13 +326,11 @@ class CoreTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "track order")
         let order = Order(id: "order-abc", amount: 120)
-        let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         testDefaults.testToken = nil
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: testSystem,
+                        system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
         core.applicationId = "app-abc123"
 
@@ -357,11 +358,9 @@ class CoreTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "track order error")
         let order = Order(id: "test", amount: 120)
-        let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let core = Core(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
                         client: testClient,
-                        system: testSystem,
+                        system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
         core.applicationId = ""
 
@@ -387,13 +386,11 @@ class CoreTests: XCTestCase {
         let order = Order(id: "order-abc", purchaseDate: date, lineItems: lineItems)
         order.customer = customer
         order.customerOrderId = "customer-order-id-123"
-        let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         testDefaults.testToken = "srctok-abc123"
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: testSystem,
+                        system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
         core.applicationId = "app-abc123"
         
@@ -426,11 +423,9 @@ class CoreTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "report order error")
         let order = Order(id: "order-abc", purchaseDate: Date(), lineItems: [])
-        let testSystem = TestSystem()
-        let testClient = TestClient(session: TestURLSession(), userAgent: TestUserAgent(system: testSystem))
         let core = Core(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
                         client: testClient,
-                        system: testSystem,
+                        system: TestSystem(),
                         notificationCenter: TestNotificationCenter())
         core.applicationId = ""
         

--- a/Tests/UnitTests/ReportOrderRequestTests.swift
+++ b/Tests/UnitTests/ReportOrderRequestTests.swift
@@ -35,22 +35,20 @@ class ReportOrderRequestTests: XCTestCase {
     let url = URL(string: "https://example.com")!
     
     override func setUp() {
-        request = ReportOrderRequest(parameters: [:], encodedApplicationId: "", retryPolicy: policy)
+        request = ReportOrderRequest(parameters: [:], retryPolicy: policy)
         urlRequest = URLRequest(url: url)
     }
     
     func testInitialization() {
         // Arrange
         let params = ["foo": "bar"]
-        let appId = "abc123"
         let policy = TestRetryPolicy()
         
         // Act
-        let request = ReportOrderRequest(parameters: params, encodedApplicationId: appId, retryPolicy: policy)
+        let request = ReportOrderRequest(parameters: params, retryPolicy: policy)
         
         // Assert
         XCTAssertEqual(request.parameters as? [String: String], params)
-        XCTAssertEqual(request.encodedApplicationId, appId)
         XCTAssertEqualReferences(request.retryPolicy as AnyObject, policy)
     }
     

--- a/Tests/UnitTests/TestObjects/TestButtonDefaults.swift
+++ b/Tests/UnitTests/TestObjects/TestButtonDefaults.swift
@@ -34,6 +34,7 @@ class TestButtonDefaults: ButtonDefaultsType {
     var didStoreToken = false
     
     var userDefaults: UserDefaultsType
+    var sessionId: String?
     var attributionToken: String? {
         get {
             return testToken

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -36,14 +36,16 @@ class TestClient: ClientType {
 
     var session: URLSessionType
     var userAgent: UserAgentType
+    var defaults: ButtonDefaultsType
 
     var postInstallCompletion: ((URL?, String?) -> Void)?
     var trackOrderCompletion: ((Error?) -> Void)?
     var reportOrderCompletion: ((Error?) -> Void)?
-
-    required init(session: URLSessionType, userAgent: UserAgentType) {
+    
+    required init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType) {
         self.session = session
         self.userAgent = userAgent
+        self.defaults = defaults
         self.testParameters = [:]
     }
     

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -34,6 +34,8 @@ class TestClient: ClientType {
     var didCallTrackOrder = false
     var didCallReportOrder = false
 
+    var applicationId: String?
+    
     var session: URLSessionType
     var userAgent: UserAgentType
     var defaults: ButtonDefaultsType


### PR DESCRIPTION
### Goals :dart:
- Add the ability to refresh the session whenever a request is made to the Button servers.

### Implementation Details :construction:
- Persists/refresh session Ids in response
- No change when no session
- Clear data on `null` session Id


