### PR TITLE
Prepare order endpoint for sessions

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -29,7 +29,7 @@ internal enum Service: String {
     
     case postInstall = "v1/web/deferred-deeplink"
     case activity = "v1/activity/order"
-    case order = "v1/mobile-order"
+    case order = "v1/app/order"
     
     static var baseURL = "https://api.usebutton.com/"
     

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -48,7 +48,11 @@ internal protocol CoreType {
  */
 final internal class Core: CoreType {
 
-    var applicationId: String?
+    var applicationId: String? {
+        didSet {
+            client.applicationId = applicationId
+        }
+    }
     var buttonDefaults: ButtonDefaultsType
     var client: ClientType
     var system: SystemType
@@ -160,8 +164,7 @@ final internal class Core: CoreType {
     }
     
     func reportOrder(_ order: Order, _ completion: ((Error?) -> Void)?) {
-        guard let appId = applicationId, !appId.isEmpty,
-            let encodedAppId = (appId + ":").data(using: .utf8)?.base64EncodedString() else {
+        guard let appId = applicationId, !appId.isEmpty else {
             if let completion = completion {
                 completion(ConfigurationError.noApplicationId)
             }
@@ -169,7 +172,7 @@ final internal class Core: CoreType {
         }
         
         let reportOrderBody = ReportOrderBody(system: system, applicationId: appId, attributionToken: buttonDefaults.attributionToken, order: order)
-        let request = ReportOrderRequest(parameters: reportOrderBody.dictionaryRepresentation, encodedApplicationId: encodedAppId)
+        let request = ReportOrderRequest(parameters: reportOrderBody.dictionaryRepresentation)
         client.reportOrder(orderRequest: request, completion)
     }
 

--- a/Source/ReportOrderRequest.swift
+++ b/Source/ReportOrderRequest.swift
@@ -26,7 +26,6 @@ import Foundation
 
 internal protocol ReportOrderRequestType {
     var parameters: [String: Any] { get }
-    var encodedApplicationId: String { get }
     var retryPolicy: RetryPolicyType { get }
     
     func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Error?) -> Void)?)
@@ -35,12 +34,10 @@ internal protocol ReportOrderRequestType {
 internal final class ReportOrderRequest: ReportOrderRequestType {
     
     var parameters: [String: Any]
-    var encodedApplicationId: String
     var retryPolicy: RetryPolicyType
     
-    required init(parameters: [String: Any], encodedApplicationId: String, retryPolicy: RetryPolicyType = RetryPolicy()) {
+    required init(parameters: [String: Any], retryPolicy: RetryPolicyType = RetryPolicy()) {
         self.parameters = parameters
-        self.encodedApplicationId = encodedApplicationId
         self.retryPolicy = retryPolicy
     }
     

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -41,43 +41,48 @@ class ClientTests: XCTestCase {
         XCTAssertEqualReferences(client.userAgent as AnyObject, expectedUserAgent)
         XCTAssertEqualReferences(client.defaults as AnyObject, defaults)
     }
-
+    
     func testURLRequestCreatedWithParameters() {
         // Arrange
         let testUserAgent = TestUserAgent()
         let expectedURL = URL(string: "https://usebutton.com")!
-        let expectedParameters = ["test": "test",
-                                  "some": "value"]
+        let inputParameters = ["test": "test", "some": "value"]
         let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
-
+        client.applicationId = "app-abc123"
+        
         // Act
-        let request = client.urlRequest(url: expectedURL, parameters: expectedParameters)
+        let request = client.urlRequest(url: expectedURL, parameters: inputParameters)
         let requestParameters = try? JSONSerialization.jsonObject(with: request.httpBody!)
         let parameters = requestParameters as? [String: String]
-
+        
         // Assert
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(request.url, expectedURL)
         XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), testUserAgent.stringRepresentation)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters!, expectedParameters)
+        XCTAssertEqual(parameters!, ["test": "test",
+                                     "some": "value",
+                                     "application_id": "app-abc123"])
     }
     
     func testURLRequest_whenSessionSet_addsSession() {
         // Arrange
         let testUserAgent = TestUserAgent()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: testDefaults)
         testDefaults.sessionId = "some-session-id"
-
+        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: testDefaults)
+        client.applicationId = "app-abc123"
+        
         // Act
         let request = client.urlRequest(url: URL(string: "https://usebutton.com")!, parameters: ["foo": "bar"])
         let requestParameters = try? JSONSerialization.jsonObject(with: request.httpBody!)
         let parameters = requestParameters as? [String: String]
 
         // Assert
-        XCTAssertEqual(parameters!, ["foo": "bar", "session_id": "some-session-id"])
+        XCTAssertEqual(parameters!, ["foo": "bar",
+                                     "session_id": "some-session-id",
+                                     "application_id": "app-abc123"])
     }
 
     func testURLRequestCreatedWithoutParameters() {
@@ -85,24 +90,45 @@ class ClientTests: XCTestCase {
         let testUserAgent = TestUserAgent()
         let expectedURL = URL(string: "https://usebutton.com")!
         let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
-
+        client.applicationId = "app-abc123"
+        
         // Act
         let request = client.urlRequest(url: expectedURL, parameters: nil)
+        let requestParameters = try? JSONSerialization.jsonObject(with: request.httpBody!)
+        let parameters = requestParameters as? [String: String]
 
         // Assert
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(request.url, expectedURL)
         XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), testUserAgent.stringRepresentation)
-        XCTAssertNil(request.value(forHTTPHeaderField: "Content-Type"))
-        XCTAssertNil(request.httpBody)
+        XCTAssertEqual(parameters!, ["application_id": "app-abc123"])
+    }
+    
+    func testURLRequestCreated_noParams_noAppId_hasEmptyParams() {
+        // Arrange
+        let testUserAgent = TestUserAgent()
+        let expectedURL = URL(string: "https://usebutton.com")!
+        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        
+        // Act
+        let request = client.urlRequest(url: expectedURL, parameters: nil)
+        let requestParameters = try? JSONSerialization.jsonObject(with: request.httpBody!)
+        let parameters = requestParameters as? [String: String]
+
+        // Assert
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url, expectedURL)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), testUserAgent.stringRepresentation)
+        XCTAssertEqual(parameters!, [:])
     }
     
     func testURLRequestNoParams_whenSessionSet_addsSession() {
         // Arrange
         let testUserAgent = TestUserAgent()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: testDefaults)
         testDefaults.sessionId = "some-session-id"
+        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: testDefaults)
+        client.applicationId = "app-abc123"
 
         // Act
         let request = client.urlRequest(url: URL(string: "https://usebutton.com")!, parameters: nil)
@@ -110,7 +136,7 @@ class ClientTests: XCTestCase {
         let parameters = requestParameters as? [String: String]
 
         // Assert
-        XCTAssertEqual(parameters!, ["session_id": "some-session-id"])
+        XCTAssertEqual(parameters!, ["session_id": "some-session-id", "application_id": "app-abc123"])
     }
     
     func testEnqueueRequestCreatesDataTask() {
@@ -456,7 +482,6 @@ class ClientTests: XCTestCase {
         }
         
         XCTAssertEqualReferences(request.testSession as AnyObject, session)
-        XCTAssertEqual(request.testRequest?.allHTTPHeaderFields!["Authorization"], "Basic abc123")
         XCTAssertEqual(request.testRequest?.url, URL(string: "https://api.usebutton.com/v1/app/order")!)
         XCTAssertEqual(request.testRequest?.httpMethod, "POST")
         let body = try? JSONSerialization.jsonObject(with: (request.testRequest?.httpBody)!) as? [String: String]

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -457,7 +457,7 @@ class ClientTests: XCTestCase {
         
         XCTAssertEqualReferences(request.testSession as AnyObject, session)
         XCTAssertEqual(request.testRequest?.allHTTPHeaderFields!["Authorization"], "Basic abc123")
-        XCTAssertEqual(request.testRequest?.url, URL(string: "https://api.usebutton.com/v1/mobile-order")!)
+        XCTAssertEqual(request.testRequest?.url, URL(string: "https://api.usebutton.com/v1/app/order")!)
         XCTAssertEqual(request.testRequest?.httpMethod, "POST")
         let body = try? JSONSerialization.jsonObject(with: (request.testRequest?.httpBody)!) as? [String: String]
         XCTAssertEqual(body, ["foo": "bar"])

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -49,6 +49,20 @@ class CoreTests: XCTestCase {
         XCTAssertEqualReferences(core.notificationCenter, testNotificationCenter)
     }
     
+    func testSetApplicationId_setClientApplicationId() {
+        // Arrange
+        let core = Core(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                        client: testClient,
+                        system: TestSystem(),
+                        notificationCenter: TestNotificationCenter())
+        
+        // Act
+        core.applicationId = "app-abc123"
+        
+        // Assert
+        XCTAssertEqual(testClient.applicationId, "app-abc123")
+    }
+    
     func testTrackIncomingURLIgnoresUnattributedURLs() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
@@ -395,7 +409,6 @@ class CoreTests: XCTestCase {
         core.applicationId = "app-abc123"
         
         // Act
-        // Act
         core.reportOrder(order) { error in
             
             // Assert
@@ -413,7 +426,6 @@ class CoreTests: XCTestCase {
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
                         "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
         
-        XCTAssertEqual(testClient.testReportOrderRequest!.encodedApplicationId, "YXBwLWFiYzEyMzo=")
         testClient.reportOrderCompletion!(nil)
         
         self.wait(for: [expectation], timeout: 2.0)

--- a/Tests/UnitTests/ReportOrderRequestTests.swift
+++ b/Tests/UnitTests/ReportOrderRequestTests.swift
@@ -35,22 +35,20 @@ class ReportOrderRequestTests: XCTestCase {
     let url = URL(string: "https://example.com")!
     
     override func setUp() {
-        request = ReportOrderRequest(parameters: [:], encodedApplicationId: "", retryPolicy: policy)
+        request = ReportOrderRequest(parameters: [:], retryPolicy: policy)
         urlRequest = URLRequest(url: url)
     }
     
     func testInitialization() {
         // Arrange
         let params = ["foo": "bar"]
-        let appId = "abc123"
         let policy = TestRetryPolicy()
         
         // Act
-        let request = ReportOrderRequest(parameters: params, encodedApplicationId: appId, retryPolicy: policy)
+        let request = ReportOrderRequest(parameters: params, retryPolicy: policy)
         
         // Assert
         XCTAssertEqual(request.parameters as? [String: String], params)
-        XCTAssertEqual(request.encodedApplicationId, appId)
         XCTAssertEqualReferences(request.retryPolicy as AnyObject, policy)
     }
     

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -34,6 +34,8 @@ class TestClient: ClientType {
     var didCallTrackOrder = false
     var didCallReportOrder = false
 
+    var applicationId: String?
+    
     var session: URLSessionType
     var userAgent: UserAgentType
     var defaults: ButtonDefaultsType


### PR DESCRIPTION
### Goals :dart:
Update to a new order endpoint for session management

### Implementation Details :construction:
- Updates order endpoint to `v1/app/order`
- Removes encoded app Id from order request
- Adds app Id to all outgoing requests

