### PR TITLE
Allow requests if configuration has been called with any value

### DIFF
--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -72,12 +72,12 @@ final public class ButtonMerchant: NSObject {
 
      */
     @objc public static func configure(applicationId: String) {
-        guard let validAppId = ApplicationId(applicationId) else {
+        let appId = ApplicationId(applicationId)
+        if appId == nil {
             let error = ConfigurationError.invalidApplicationId(appicationId: applicationId)
             print("Button :: \(error.localizedDescription)")
-            return
         }
-        core.applicationId = validAppId
+        core.applicationId = appId
     }
     
     /**

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -74,6 +74,7 @@ final internal class Core: CoreType {
                   client: ClientType,
                   system: SystemType,
                   notificationCenter: NotificationCenterType) {
+        self.applicationId = nil
         self.buttonDefaults = buttonDefaults
         self.client = client
         self.system = system

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -35,6 +35,7 @@ class TestClient: ClientType {
     var didCallReportOrder = false
     var didCallReportEvents = false
 
+    var isConfigured: Bool = true
     var applicationId: ApplicationId?
     
     var session: URLSessionType


### PR DESCRIPTION
### Goals :dart:
Allow requests to be sent if configure(applicationId:) has been called with _any_ value.

### Implementation Details :construction:
- Allows requests to proceed and flush regardless of valid appId to help identify integration errors.

