### PR TITLE
Persist session_id from order response

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -99,7 +99,12 @@ internal final class Client: ClientType {
     
     func reportOrder(orderRequest: ReportOrderRequestType, _ completion: ((Error?) -> Void)?) {
         let request = urlRequest(url: Service.order.urlWith(applicationId), parameters: orderRequest.parameters)
-        orderRequest.report(request, with: session, completion)
+        orderRequest.report(request, with: session) { data, error in
+            self.refreshSessionIfAvailable(responseData: data)
+            if let completion = completion {
+                completion(error)
+            }
+        }
     }
     
     func reportEvents(_ events: [AppEvent], ifa: String?, _ completion: ((Error?) -> Void)?) {

--- a/Source/ReportOrderRequest.swift
+++ b/Source/ReportOrderRequest.swift
@@ -28,7 +28,7 @@ internal protocol ReportOrderRequestType {
     var parameters: [String: Any] { get }
     var retryPolicy: RetryPolicyType { get }
     
-    func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Error?) -> Void)?)
+    func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Data?, Error?) -> Void)?)
 }
 
 internal final class ReportOrderRequest: ReportOrderRequestType {
@@ -41,7 +41,7 @@ internal final class ReportOrderRequest: ReportOrderRequestType {
         self.retryPolicy = retryPolicy
     }
     
-    func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Error?) -> Void)?) {
+    func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Data?, Error?) -> Void)?) {
         let task = session.dataTask(with: request) { data, response, error in
             var nextAttempt = true
             var networkError: Error? = NetworkError.unknown
@@ -58,7 +58,7 @@ internal final class ReportOrderRequest: ReportOrderRequestType {
             }
             guard nextAttempt else {
                 if let completion = completion {
-                    completion(networkError)
+                    completion(data, networkError)
                 }
                 return
             }
@@ -67,7 +67,7 @@ internal final class ReportOrderRequest: ReportOrderRequestType {
             
             guard self.retryPolicy.shouldRetry else {
                 if let completion = completion {
-                    completion(networkError)
+                    completion(data, networkError)
                 }
                 return
             }

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -204,7 +204,7 @@ class ClientTests: XCTestCase {
         self.wait(for: [expectation], timeout: 2.0)
     }
     
-    func testEnqueueRequestSuccess_whenSession_persistsSession() {
+    func testEnqueueRequestSuccess_whenSessionId_persistsSessionId() {
         // Arrange
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
@@ -229,7 +229,7 @@ class ClientTests: XCTestCase {
         self.wait(for: [expectation], timeout: 2.0)
     }
     
-    func testEnqueueRequestSuccess_whenNoSession_noChange() {
+    func testEnqueueRequestSuccess_whenNoSessionId_noChange() {
         // Arrange
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
@@ -256,7 +256,7 @@ class ClientTests: XCTestCase {
         self.wait(for: [expectation], timeout: 2.0)
     }
     
-    func testEnqueueRequestSuccess_whenNewSession_persistsNewSession() {
+    func testEnqueueRequestSuccess_whenNewSessionId_persistsNewSessionId() {
         // Arrange
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
@@ -283,7 +283,7 @@ class ClientTests: XCTestCase {
         self.wait(for: [expectation], timeout: 2.0)
     }
     
-    func testEnqueueRequestSuccess_whenSessionNull_clearsAllData() {
+    func testEnqueueRequestSuccess_whenSessionIdNull_clearsAllData() {
         // Arrange
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
@@ -465,7 +465,7 @@ class ClientTests: XCTestCase {
         let session = TestURLSession()
         let client = Client(session: session, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
         client.applicationId = ApplicationId("app-abc123")
-        let request = TestReportOrderRequest(parameters: ["foo": "bar"], encodedApplicationId: "abc123")
+        let request = TestReportOrderRequest(parameters: ["foo": "bar"])
         
         // Act
         client.reportOrder(orderRequest: request) { error in
@@ -482,7 +482,30 @@ class ClientTests: XCTestCase {
         let body = try? JSONSerialization.jsonObject(with: (request.testRequest?.httpBody)!) as? [String: String]
         XCTAssertEqual(body, ["foo": "bar", "application_id": "app-abc123"])
         
-        request.testCompletion!(nil)
+        request.testCompletion!(Data(), nil)
+        
+        wait(for: [expectation], timeout: 2.0)
+    }
+    
+    func testReportOrder_whenSessionId_persistsSessionId() {
+        // Arrange
+        let expectation = XCTestExpectation(description: "report order persists session id")
+        let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
+        let client = Client(session: TestURLSession(), userAgent: TestUserAgent(), defaults: testDefaults)
+        client.applicationId = ApplicationId("app-abc123")
+        let request = TestReportOrderRequest(parameters: ["foo": "bar"])
+        let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["session_id": "some-session-id"]])
+        
+        // Act
+        client.reportOrder(orderRequest: request) { error in
+            
+            // Assert
+            XCTAssertNil(error)
+            XCTAssertEqual(testDefaults.sessionId, "some-session-id")
+            
+            expectation.fulfill()
+        }
+        request.testCompletion!(responseData, nil)
         
         wait(for: [expectation], timeout: 2.0)
     }

--- a/Tests/UnitTests/ReportOrderRequestTests.swift
+++ b/Tests/UnitTests/ReportOrderRequestTests.swift
@@ -83,7 +83,7 @@ class ReportOrderRequestTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "200")
         
-        request.report(urlRequest, with: session) { error in
+        request.report(urlRequest, with: session) { _, error in
             
             // Assert
             XCTAssertNil(error)
@@ -103,7 +103,7 @@ class ReportOrderRequestTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "400")
         
-        request.report(urlRequest, with: session) { error in
+        request.report(urlRequest, with: session) { _, error in
             
             // Assert
             XCTAssertEqual(error as? NetworkError, NetworkError.unknown)
@@ -148,7 +148,7 @@ class ReportOrderRequestTests: XCTestCase {
         let expectation = XCTestExpectation(description: "no retry finish")
         policy.shouldRetry = false
         
-        request.report(urlRequest, with: session) { error in
+        request.report(urlRequest, with: session) { _, error in
             
             // Assert
             XCTAssertEqual(error as? NetworkError, NetworkError.unknown)

--- a/Tests/UnitTests/TestObjects/TestReportOrderRequest.swift
+++ b/Tests/UnitTests/TestObjects/TestReportOrderRequest.swift
@@ -27,21 +27,19 @@ import Foundation
 
 class TestReportOrderRequest: ReportOrderRequestType {
     var parameters: [String: Any]
-    var encodedApplicationId: String
     var retryPolicy: RetryPolicyType
     
     var didCallReport = false
     var testRequest: URLRequest?
     var testSession: URLSessionType?
-    var testCompletion: ((Error?) -> Void)?
+    var testCompletion: ((Data?, Error?) -> Void)?
     
-    required init(parameters: [String: Any], encodedApplicationId: String, retryPolicy: RetryPolicyType = RetryPolicy()) {
+    required init(parameters: [String: Any], retryPolicy: RetryPolicyType = RetryPolicy()) {
         self.parameters = parameters
-        self.encodedApplicationId = encodedApplicationId
         self.retryPolicy = retryPolicy
     }
     
-    func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Error?) -> Void)?) {
+    func report(_ request: URLRequest, with session: URLSessionType, _ completion: ((Data?, Error?) -> Void)?) {
         didCallReport = true
         testRequest = request
         testSession = session


### PR DESCRIPTION
### Goals :dart:
Ensure that responses from reporting an order also persist the session

