### PR TITLE
Clear pending tasks when clearAllData is called

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -53,7 +53,7 @@ internal protocol ClientType: class {
     var session: URLSessionType { get }
     var userAgent: UserAgentType { get }
     var defaults: ButtonDefaultsType { get }
-    var pendingTasks: [PendingTask] { get }
+    var pendingTasks: [PendingTask] { get set }
     func fetchPostInstallURL(parameters: [String: Any], _ completion: @escaping (URL?, String?) -> Void)
     func reportOrder(orderRequest: ReportOrderRequestType, _ completion: ((Error?) -> Void)?)
     func reportEvents(_ events: [AppEvent], ifa: String?, _ completion: ((Error?) -> Void)?)

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -86,6 +86,7 @@ final internal class Core: CoreType {
      */
     func clearAllData() {
         buttonDefaults.clearAllData()
+        client.pendingTasks.removeAll()
     }
 
     /**

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -336,6 +336,23 @@ class CoreTests: XCTestCase {
         // Assert
         XCTAssertTrue(testDefaults.didCallClearAllData)
     }
+    
+    func testClearAllDataRemovesPendingTasks() {
+        // Arrange
+        let request = URLRequest(url: URL(string: "https://example.com")!)
+        let task = PendingTask(urlRequest: request) { _, _ in }
+        testClient.pendingTasks.append(task)
+        let core = Core(buttonDefaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                        client: testClient,
+                        system: TestSystem(),
+                        notificationCenter: TestNotificationCenter())
+
+        // Act
+        core.clearAllData()
+        
+        // Assert
+        XCTAssertTrue(testClient.pendingTasks.isEmpty)
+    }
 
     func testHandlePostInstallURL() {
         // Arrange


### PR DESCRIPTION
### Goals :dart:
`clearAllData()` currently erases the defaults (`sessionId` and `attributionToken`), but with the `pendingTasks` we've added another type of persistence. This PR makes sure those are cleared as well.