### PR TITLE
Add user activity reporting

### DIFF
--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		DA98C00622B29BA0002D1823 /* PEMCertificate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA98C00522B29BA0002D1823 /* PEMCertificate.swift */; };
 		DAA3F29924E2F7D40046DA61 /* ButtonProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */; };
 		DAA3F29C24E305C60046DA61 /* ButtonProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */; };
+		DAA3F29E24E322C70046DA61 /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29D24E322C70046DA61 /* Activity.swift */; };
 		DAB8DFC42316EB3200E16619 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB8DFC32316EB3200E16619 /* NetworkError.swift */; };
 		DADE90C2209B9A630073144B /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADE90C1209B9A630073144B /* TestError.swift */; };
 		DAE8B96F22AF5F0700D11AF9 /* TrustEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */; };
@@ -231,6 +232,7 @@
 		DA98C00522B29BA0002D1823 /* PEMCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PEMCertificate.swift; sourceTree = "<group>"; };
 		DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonProduct.swift; sourceTree = "<group>"; };
 		DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonProductTests.swift; sourceTree = "<group>"; };
+		DAA3F29D24E322C70046DA61 /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
 		DAB8DFC32316EB3200E16619 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		DADE90C1209B9A630073144B /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrustEvaluator.swift; sourceTree = "<group>"; };
@@ -629,6 +631,7 @@
 				FB70030724CF2FDE0050E021 /* AppEventsRequestBody.swift */,
 				FB70030E24CF48A90050E021 /* AppEvent.swift */,
 				DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */,
+				DAA3F29D24E322C70046DA61 /* Activity.swift */,
 				9E77202020605126005F740B /* Extensions */,
 				DE865FA42053073B00F4054D /* Supporting Files */,
 			);
@@ -1146,6 +1149,7 @@
 				DE2F7450208F6552001E4BD6 /* ConfigurationError.swift in Sources */,
 				DCF4AD0422B421FB000DA3B2 /* ReportOrderBody.swift in Sources */,
 				FB70030F24CF48A90050E021 /* AppEvent.swift in Sources */,
+				DAA3F29E24E322C70046DA61 /* Activity.swift in Sources */,
 				DE865FA620530BCE00F4054D /* ButtonMerchant.swift in Sources */,
 				9E56CE5A22B812AE00E75884 /* StringExtensions.swift in Sources */,
 				9E2B4317206C1335009F2886 /* EncodableExtensions.swift in Sources */,

--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -85,7 +85,9 @@
 		DAA3F29924E2F7D40046DA61 /* ButtonProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */; };
 		DAA3F29C24E305C60046DA61 /* ButtonProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */; };
 		DAA3F29E24E322C70046DA61 /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29D24E322C70046DA61 /* Activity.swift */; };
+		DAA3F2A024E32EA50046DA61 /* ActivityRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29F24E32EA50046DA61 /* ActivityRequestBody.swift */; };
 		DAB8DFC42316EB3200E16619 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB8DFC32316EB3200E16619 /* NetworkError.swift */; };
+		DAD885D124E41B4100E138BF /* ActivityRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD885D024E41B4100E138BF /* ActivityRequestBodyTests.swift */; };
 		DADE90C2209B9A630073144B /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADE90C1209B9A630073144B /* TestError.swift */; };
 		DAE8B96F22AF5F0700D11AF9 /* TrustEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */; };
 		DC1F008122CA85F000E789D0 /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1F008022CA85F000E789D0 /* Configurable.swift */; };
@@ -233,7 +235,9 @@
 		DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonProduct.swift; sourceTree = "<group>"; };
 		DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonProductTests.swift; sourceTree = "<group>"; };
 		DAA3F29D24E322C70046DA61 /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
+		DAA3F29F24E32EA50046DA61 /* ActivityRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRequestBody.swift; sourceTree = "<group>"; };
 		DAB8DFC32316EB3200E16619 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		DAD885D024E41B4100E138BF /* ActivityRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRequestBodyTests.swift; sourceTree = "<group>"; };
 		DADE90C1209B9A630073144B /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrustEvaluator.swift; sourceTree = "<group>"; };
 		DC1F008022CA85F000E789D0 /* Configurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurable.swift; sourceTree = "<group>"; };
@@ -414,6 +418,7 @@
 				FB70031024CF4BC60050E021 /* AppEventTests.swift */,
 				FB5AA6AC24D0A19B0057F3A0 /* ApplicationIdTests.swift */,
 				DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */,
+				DAD885D024E41B4100E138BF /* ActivityRequestBodyTests.swift */,
 				DE175A2320A0EF12005C97B9 /* Extensions */,
 				DEE61B2B206569EA0039E47A /* TestExtensions */,
 				DA0FA2A1205C1EE8008296A6 /* TestObjects */,
@@ -632,6 +637,7 @@
 				FB70030E24CF48A90050E021 /* AppEvent.swift */,
 				DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */,
 				DAA3F29D24E322C70046DA61 /* Activity.swift */,
+				DAA3F29F24E32EA50046DA61 /* ActivityRequestBody.swift */,
 				9E77202020605126005F740B /* Extensions */,
 				DE865FA42053073B00F4054D /* Supporting Files */,
 			);
@@ -1174,6 +1180,7 @@
 				FB5AA6AE24D0BADD0057F3A0 /* ApplicationId.swift in Sources */,
 				DA0FA2A0205C1B3A008296A6 /* Core.swift in Sources */,
 				DC1F008122CA85F000E789D0 /* Configurable.swift in Sources */,
+				DAA3F2A024E32EA50046DA61 /* ActivityRequestBody.swift in Sources */,
 				DE95967E20856626004BC9EA /* ASIdentifierManagerExtensions.swift in Sources */,
 				DA4AF059208699CA002C3E0E /* NotificationExtensions.swift in Sources */,
 				9E976B87207D1A3000783F1A /* DateExtensions.swift in Sources */,
@@ -1206,6 +1213,7 @@
 				DA756B7922B2DB67003397E3 /* SessionDelegateTests.swift in Sources */,
 				FB70030B24CF46260050E021 /* AppEventRequestBodyTests.swift in Sources */,
 				9E4C496820616B040053E4CA /* ButtonDefaultsTests.swift in Sources */,
+				DAD885D124E41B4100E138BF /* ActivityRequestBodyTests.swift in Sources */,
 				9E6F4341206C160C004242A1 /* TestClient.swift in Sources */,
 				FB5AA6AD24D0A19B0057F3A0 /* ApplicationIdTests.swift in Sources */,
 				9E4C496720616B040053E4CA /* CoreTests.swift in Sources */,

--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		DA756B8722B3ECE9003397E3 /* TrustEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA756B8622B3ECE9003397E3 /* TrustEvaluatorTests.swift */; };
 		DA756B8922B40207003397E3 /* TestURLProtectionSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA756B8822B40207003397E3 /* TestURLProtectionSpace.swift */; };
 		DA98C00622B29BA0002D1823 /* PEMCertificate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA98C00522B29BA0002D1823 /* PEMCertificate.swift */; };
+		DAA3F29924E2F7D40046DA61 /* ButtonProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */; };
+		DAA3F29C24E305C60046DA61 /* ButtonProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */; };
 		DAB8DFC42316EB3200E16619 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB8DFC32316EB3200E16619 /* NetworkError.swift */; };
 		DADE90C2209B9A630073144B /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADE90C1209B9A630073144B /* TestError.swift */; };
 		DAE8B96F22AF5F0700D11AF9 /* TrustEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */; };
@@ -227,6 +229,8 @@
 		DA756B8622B3ECE9003397E3 /* TrustEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustEvaluatorTests.swift; sourceTree = "<group>"; };
 		DA756B8822B40207003397E3 /* TestURLProtectionSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLProtectionSpace.swift; sourceTree = "<group>"; };
 		DA98C00522B29BA0002D1823 /* PEMCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PEMCertificate.swift; sourceTree = "<group>"; };
+		DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonProduct.swift; sourceTree = "<group>"; };
+		DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonProductTests.swift; sourceTree = "<group>"; };
 		DAB8DFC32316EB3200E16619 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		DADE90C1209B9A630073144B /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		DAE8B96D22AF5F0400D11AF9 /* TrustEvaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrustEvaluator.swift; sourceTree = "<group>"; };
@@ -404,13 +408,14 @@
 				DC4AAD4322B13CD3005CE460 /* OrderTests.swift */,
 				DA191A2722D530CC00ED88B9 /* ReportOrderRequestTests.swift */,
 				DA4C8C7C22D3DC0D000E15A9 /* RetryPolicyTests.swift */,
+				FB70030924CF44620050E021 /* AppEventRequestBodyTests.swift */,
+				FB70031024CF4BC60050E021 /* AppEventTests.swift */,
+				FB5AA6AC24D0A19B0057F3A0 /* ApplicationIdTests.swift */,
+				DAA3F29A24E305790046DA61 /* ButtonProductTests.swift */,
 				DE175A2320A0EF12005C97B9 /* Extensions */,
 				DEE61B2B206569EA0039E47A /* TestExtensions */,
 				DA0FA2A1205C1EE8008296A6 /* TestObjects */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
-				FB70030924CF44620050E021 /* AppEventRequestBodyTests.swift */,
-				FB70031024CF4BC60050E021 /* AppEventTests.swift */,
-				FB5AA6AC24D0A19B0057F3A0 /* ApplicationIdTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -621,10 +626,11 @@
 				DE2F744E208F6535001E4BD6 /* ConfigurationError.swift */,
 				DAB8DFC32316EB3200E16619 /* NetworkError.swift */,
 				FB5AA6AA24D0A11D0057F3A0 /* ApplicationId.swift */,
-				9E77202020605126005F740B /* Extensions */,
-				DE865FA42053073B00F4054D /* Supporting Files */,
 				FB70030724CF2FDE0050E021 /* AppEventsRequestBody.swift */,
 				FB70030E24CF48A90050E021 /* AppEvent.swift */,
+				DAA3F29824E2F7D40046DA61 /* ButtonProduct.swift */,
+				9E77202020605126005F740B /* Extensions */,
+				DE865FA42053073B00F4054D /* Supporting Files */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1168,6 +1174,7 @@
 				DA4AF059208699CA002C3E0E /* NotificationExtensions.swift in Sources */,
 				9E976B87207D1A3000783F1A /* DateExtensions.swift in Sources */,
 				9EB1B0A2207AB5ED00BE0A1A /* FileManagerExtensions.swift in Sources */,
+				DAA3F29924E2F7D40046DA61 /* ButtonProduct.swift in Sources */,
 				9E2B4311206C1275009F2886 /* Client.swift in Sources */,
 				DAB8DFC42316EB3200E16619 /* NetworkError.swift in Sources */,
 				DA4C8C7B22D3D956000E15A9 /* RetryPolicy.swift in Sources */,
@@ -1217,6 +1224,7 @@
 				DE175A2120A0AFF6005C97B9 /* VersionTests.generated.swift in Sources */,
 				9E5475E4206D91A900947A1C /* TestURLSessionDataTask.swift in Sources */,
 				DE1706E5208563D7009FF30B /* TestLocale.swift in Sources */,
+				DAA3F29C24E305C60046DA61 /* ButtonProductTests.swift in Sources */,
 				DA191A2822D530CC00ED88B9 /* ReportOrderRequestTests.swift in Sources */,
 				9EDED112208FA4D70049A56A /* TestBundle.swift in Sources */,
 				DA756B8122B2E03E003397E3 /* TestURLAuthenticationChallenge.swift in Sources */,

--- a/Source/Activity.swift
+++ b/Source/Activity.swift
@@ -1,0 +1,52 @@
+//
+// Activity.swift
+//
+// Copyright © 2020 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+@objc public protocol Activity: class {
+    
+    /**
+     Report that the user has viewed a product.
+
+     - Parameters:
+     - product: The product being viewed.
+     */
+    func productViewed(_ product: ButtonProductCompatible?)
+    
+    /**
+     Report that the user added a product to their cart.
+
+     - Parameters:
+     - product: The product added to the cart.
+    */
+    func productAddedToCard(_ product: ButtonProductCompatible?)
+    
+    /**
+     Report that the user viewed their cart.
+
+     - Parameters:
+     - products: The list of products in the cart.
+    */
+    func cartViewed(_ products: [ButtonProductCompatible]?)
+}

--- a/Source/Activity.swift
+++ b/Source/Activity.swift
@@ -24,6 +24,9 @@
 
 import Foundation
 
+/**
+ A protocol through which user activities can be reported.
+ */
 @objc public protocol Activity: class {
     
     /**

--- a/Source/Activity.swift
+++ b/Source/Activity.swift
@@ -40,7 +40,7 @@ import Foundation
      - Parameters:
      - product: The product added to the cart.
     */
-    func productAddedToCard(_ product: ButtonProductCompatible?)
+    func productAddedToCart(_ product: ButtonProductCompatible?)
     
     /**
      Report that the user viewed their cart.

--- a/Source/ActivityRequestBody.swift
+++ b/Source/ActivityRequestBody.swift
@@ -26,6 +26,7 @@ import Foundation
 
 internal struct ActivityRequestBody {
     let ifa: String?
+    let attributionToken: String?
     let name: String
     let products: [ButtonProductCompatible]?
     
@@ -33,6 +34,9 @@ internal struct ActivityRequestBody {
         var dict: [String: Any] = ["name": name]
         if let ifa = ifa {
             dict["ifa"] = ifa
+        }
+        if let attributionToken = attributionToken {
+            dict["btn_ref"] = attributionToken
         }
         if let products = products {
             dict["products"] = products.map { product -> [String: Any] in

--- a/Source/ActivityRequestBody.swift
+++ b/Source/ActivityRequestBody.swift
@@ -31,48 +31,32 @@ internal struct ActivityRequestBody {
     let products: [ButtonProductCompatible]?
     
     var dictionaryRepresentation: [String: Any] {
-        var dict = [String: Any]()
-        if let ifa = ifa {
-            dict["ifa"] = ifa
-        }
-        if let attributionToken = attributionToken {
-            dict["btn_ref"] = attributionToken
-        }
-        var data: [String: Any] = ["name": name]
+        var dict: [String: Any?] = [
+            "ifa": ifa,
+            "btn_ref": attributionToken
+        ]
+        var data: [String: Any?] = ["name": name]
         if let products = products {
             data["products"] = products.map { product -> [String: Any] in
-                var productDict = [String: Any]()
-                if let id = product.id {
-                    productDict["id"] = id
-                }
-                if let upc = product.upc {
-                    productDict["upc"] = upc
-                }
-                if let categories = product.categories {
-                    productDict["categories"] = categories
-                }
-                if let name = product.name {
-                    productDict["name"] = name
-                }
-                if let currency = product.currency {
-                    productDict["currency"] = currency
-                }
-                if let url = product.url {
-                    productDict["url"] = url
-                }
-                if let attributes = product.attributes {
-                    productDict["attributes"] = attributes
-                }
+                var productDict: [String: Any?] = [
+                    "id": product.id,
+                    "upc": product.upc,
+                    "categories": product.categories,
+                    "name": product.name,
+                    "currency": product.currency,
+                    "url": product.url,
+                    "attributes": product.attributes
+                ]
                 if product.value != 0 {
                     productDict["value"] = product.value
                 }
                 if product.quantity != 0 {
                     productDict["quantity"] = product.quantity
                 }
-                return productDict
+                return productDict.compactMapValues { $0 }
             }
         }
         dict["activity_data"] = data
-        return dict
+        return dict.compactMapValues { $0 }
     }
 }

--- a/Source/ActivityRequestBody.swift
+++ b/Source/ActivityRequestBody.swift
@@ -1,0 +1,72 @@
+//
+// ActivityRequestBody.swift
+//
+// Copyright © 2020 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+	
+import Foundation
+
+internal struct ActivityRequestBody {
+    let ifa: String?
+    let name: String
+    let products: [ButtonProductCompatible]?
+    
+    var dictionaryRepresentation: [String: Any] {
+        var dict: [String: Any] = ["name": name]
+        if let ifa = ifa {
+            dict["ifa"] = ifa
+        }
+        if let products = products {
+            dict["products"] = products.map { product -> [String: Any] in
+                var productDict = [String: Any]()
+                if let id = product.id {
+                    productDict["id"] = id
+                }
+                if let upc = product.upc {
+                    productDict["upc"] = upc
+                }
+                if let categories = product.categories {
+                    productDict["categories"] = categories
+                }
+                if let name = product.name {
+                    productDict["name"] = name
+                }
+                if let currency = product.currency {
+                    productDict["currency"] = currency
+                }
+                if let url = product.url {
+                    productDict["url"] = url
+                }
+                if let attributes = product.attributes {
+                    productDict["attributes"] = attributes
+                }
+                if product.value != 0 {
+                    productDict["value"] = product.value
+                }
+                if product.quantity != 0 {
+                    productDict["quantity"] = product.quantity
+                }
+                return productDict
+            }
+        }
+        return dict
+    }
+}

--- a/Source/ActivityRequestBody.swift
+++ b/Source/ActivityRequestBody.swift
@@ -31,15 +31,16 @@ internal struct ActivityRequestBody {
     let products: [ButtonProductCompatible]?
     
     var dictionaryRepresentation: [String: Any] {
-        var dict: [String: Any] = ["name": name]
+        var dict = [String: Any]()
         if let ifa = ifa {
             dict["ifa"] = ifa
         }
         if let attributionToken = attributionToken {
             dict["btn_ref"] = attributionToken
         }
+        var data: [String: Any] = ["name": name]
         if let products = products {
-            dict["products"] = products.map { product -> [String: Any] in
+            data["products"] = products.map { product -> [String: Any] in
                 var productDict = [String: Any]()
                 if let id = product.id {
                     productDict["id"] = id
@@ -71,6 +72,7 @@ internal struct ActivityRequestBody {
                 return productDict
             }
         }
+        dict["activity_data"] = data
         return dict
     }
 }

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -185,11 +185,12 @@ final public class ButtonMerchant: NSObject {
                             locale: NSLocale.current,
                             bundle: Bundle.main)
         let session = URLSession(configuration: .default, delegate: SessionDelegate(system: system), delegateQueue: nil)
-        let buttonDetaults = ButtonDefaults(userDefaults: UserDefaults.button)
+        let buttonDefaults = ButtonDefaults(userDefaults: UserDefaults.button)
         let client = Client(session: session,
                             userAgent: UserAgent(libraryVersion: Version.stringValue, system: system),
-                            defaults: buttonDetaults)
-        return Core(buttonDefaults: buttonDetaults,
+                            defaults: buttonDefaults,
+                            system: system)
+        return Core(buttonDefaults: buttonDefaults,
                     client: client,
                     system: system,
                     notificationCenter: NotificationCenter.default)

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -167,6 +167,13 @@ final public class ButtonMerchant: NSObject {
         return core.system
     }
     
+    /**
+     An interface through which user activity can be reported.
+     */
+    @objc public static var activity: Activity {
+        return core.client
+    }
+    
     // MARK: Private
     
     private static func createCore() -> CoreType {

--- a/Source/ButtonProduct.swift
+++ b/Source/ButtonProduct.swift
@@ -1,0 +1,91 @@
+//
+// ButtonProduct.swift
+//
+// Copyright © 2020 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+	
+import Foundation
+
+/**
+ A protocol that defines the product properties that may be provided when reporting user activity.
+ */
+@objc public protocol ButtonProductCompatible: class {
+    
+    /**
+     The product identifier.
+     */
+    var id: String? { get }
+
+    /**
+     The UPC (Universal Product Code) of the product.
+     */
+    var upc: String? { get }
+
+    /**
+     A flat array of the names of the categories to which the product belongs.
+     */
+    var categories: [String]? { get }
+
+    /**
+     The name of the product.
+     */
+    var name: String? { get }
+
+    /**
+     The ISO-4217 currency code in which the product's value is reported.
+     */
+    var currency: String? { get }
+
+    /**
+     The value of the order. Includes any discounts, if applicable. Example: 1234 for $12.34.
+     */
+    var value: Int { get }
+
+    /**
+     The quantity of the product.
+     */
+    var quantity: Int { get }
+
+    /**
+     The URL of the product.
+     */
+    var url: String? { get }
+
+    /**
+     Any additional attributes to be included with the product.
+     */
+    var attributes: [String: String]? { get }
+}
+
+/**
+ A concrete implementation of the ButtonProductCompatible protocol.
+ */
+final public class ButtonProduct: NSObject, ButtonProductCompatible {
+    public var id: String?
+    public var upc: String?
+    public var categories: [String]?
+    public var name: String?
+    public var currency: String?
+    public var value: Int = 0
+    public var quantity: Int = 0
+    public var url: String?
+    public var attributes: [String: String]?
+}

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -53,11 +53,12 @@ internal protocol ClientType: Activity {
     var session: URLSessionType { get }
     var userAgent: UserAgentType { get }
     var defaults: ButtonDefaultsType { get }
+    var system: SystemType { get }
     var pendingTasks: [PendingTask] { get set }
     func fetchPostInstallURL(parameters: [String: Any], _ completion: @escaping (URL?, String?) -> Void)
     func reportOrder(orderRequest: ReportOrderRequestType, _ completion: ((Error?) -> Void)?)
     func reportEvents(_ events: [AppEvent], ifa: String?, _ completion: ((Error?) -> Void)?)
-    init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType)
+    init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType, system: SystemType)
 }
 
 internal final class Client: ClientType {
@@ -71,13 +72,15 @@ internal final class Client: ClientType {
     var session: URLSessionType
     var userAgent: UserAgentType
     var defaults: ButtonDefaultsType
+    var system: SystemType
     var pendingTasks = [PendingTask]()
     
-    init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType) {
+    init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType, system: SystemType) {
         self.applicationId = nil
         self.session = session
         self.userAgent = userAgent
         self.defaults = defaults
+        self.system = system
     }
     
     func fetchPostInstallURL(parameters: [String: Any], _ completion: @escaping (URL?, String?) -> Void) {

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -30,6 +30,7 @@ internal enum Service: String {
     case postInstall = "v1/app/deferred-deeplink"
     case order       = "v1/app/order"
     case appEvents   = "v1/app/events"
+    case activity    = "v1/app/activity"
     
     static let baseURL = "https://mobileapi.usebutton.com/"
     static let formattedBaseURL = "https://%@.mobileapi.usebutton.com/"
@@ -127,15 +128,15 @@ internal final class Client: ClientType {
     }
     
     func productViewed(_ product: ButtonProductCompatible?) {
-        
+        reportActivity("product-viewed", products: [product].compactMap { $0 })
     }
     
-    func productAddedToCard(_ product: ButtonProductCompatible?) {
-        
+    func productAddedToCart(_ product: ButtonProductCompatible?) {
+        reportActivity("add-to-cart", products: [product].compactMap { $0 })
     }
     
     func cartViewed(_ products: [ButtonProductCompatible]?) {
-        
+        reportActivity("cart-viewed", products: products)
     }
     
     private func flushPendingRequests() {
@@ -216,6 +217,14 @@ internal extension Client {
             defaults.clearAllData()
         default:
             break
+        }
+    }
+    
+    func reportActivity(_ name: String, products: [ButtonProductCompatible]?) {
+        let body = ActivityRequestBody(ifa: system.advertisingId, name: name, products: products)
+        let request = urlRequest(url: Service.activity.urlWith(applicationId), parameters: body.dictionaryRepresentation)
+        enqueueRequest(request: request) { _, _ in
+            
         }
     }
 }

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -47,7 +47,7 @@ internal struct PendingTask {
     var completion: (Data?, Error?) -> Void
 }
 
-internal protocol ClientType: class {
+internal protocol ClientType: Activity {
     var isConfigured: Bool { get set }
     var applicationId: ApplicationId? { get set }
     var session: URLSessionType { get }
@@ -121,6 +121,18 @@ internal final class Client: ClientType {
                 completion(error)
             }
         }
+    }
+    
+    func productViewed(_ product: ButtonProductCompatible?) {
+        
+    }
+    
+    func productAddedToCard(_ product: ButtonProductCompatible?) {
+        
+    }
+    
+    func cartViewed(_ products: [ButtonProductCompatible]?) {
+        
     }
     
     private func flushPendingRequests() {

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -221,7 +221,7 @@ internal extension Client {
     }
     
     func reportActivity(_ name: String, products: [ButtonProductCompatible]?) {
-        let body = ActivityRequestBody(ifa: system.advertisingId, name: name, products: products)
+        let body = ActivityRequestBody(ifa: system.advertisingId, attributionToken: ButtonMerchant.attributionToken, name: name, products: products)
         let request = urlRequest(url: Service.activity.urlWith(applicationId), parameters: body.dictionaryRepresentation)
         enqueueRequest(request: request) { _, _ in
             

--- a/Tests/UnitTests/ActivityRequestBodyTests.swift
+++ b/Tests/UnitTests/ActivityRequestBodyTests.swift
@@ -30,7 +30,7 @@ class ActivityRequestBodyTests: XCTestCase {
     func testInitialization_createsInstance() {
         let product = ButtonProduct()
         product.id = "some id"
-        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: [product])
+        let body = ActivityRequestBody(ifa: "some ifa", attributionToken: "some srctok", name: "some name", products: [product])
         XCTAssertNotNil(body)
         XCTAssertEqual(body.ifa, "some ifa")
         XCTAssertEqual(body.name, "some name")
@@ -38,17 +38,22 @@ class ActivityRequestBodyTests: XCTestCase {
     }
     
     func testDictionaryRepresentation_noIFA() {
-        let body = ActivityRequestBody(ifa: nil, name: "some name", products: nil)
+        let body = ActivityRequestBody(ifa: nil, attributionToken: nil, name: "some name", products: nil)
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name"])
     }
     
     func testDictionaryRepresentation_withIFA() {
-        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: nil)
+        let body = ActivityRequestBody(ifa: "some ifa", attributionToken: nil, name: "some name", products: nil)
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name", "ifa": "some ifa"])
     }
     
+    func testDictionaryRepresentation_withAttributionToken() {
+        let body = ActivityRequestBody(ifa: nil, attributionToken: "some srctok", name: "some name", products: nil)
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name", "btn_ref": "some srctok"])
+    }
+    
     func testDictionaryRepresentation_emptyProducts() {
-        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: [ButtonProduct(), ButtonProduct()])
+        let body = ActivityRequestBody(ifa: "some ifa", attributionToken: nil, name: "some name", products: [ButtonProduct(), ButtonProduct()])
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
                        [
                         "name": "some name",
@@ -68,7 +73,7 @@ class ActivityRequestBodyTests: XCTestCase {
         product.quantity = 25
         product.url = "example.com"
         product.attributes = ["a": "z", "b": "y"]
-        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: [product])
+        let body = ActivityRequestBody(ifa: "some ifa", attributionToken: nil, name: "some name", products: [product])
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
                        [
                         "name": "some name",

--- a/Tests/UnitTests/ActivityRequestBodyTests.swift
+++ b/Tests/UnitTests/ActivityRequestBodyTests.swift
@@ -1,0 +1,91 @@
+//
+// ActivityRequestBodyTests.swift
+//
+// Copyright © 2020 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+	
+import XCTest
+@testable import ButtonMerchant
+
+class ActivityRequestBodyTests: XCTestCase {
+    
+    func testInitialization_createsInstance() {
+        let product = ButtonProduct()
+        product.id = "some id"
+        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: [product])
+        XCTAssertNotNil(body)
+        XCTAssertEqual(body.ifa, "some ifa")
+        XCTAssertEqual(body.name, "some name")
+        XCTAssertEqual(body.products?.first?.id, "some id")
+    }
+    
+    func testDictionaryRepresentation_noIFA() {
+        let body = ActivityRequestBody(ifa: nil, name: "some name", products: nil)
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name"])
+    }
+    
+    func testDictionaryRepresentation_withIFA() {
+        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: nil)
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name", "ifa": "some ifa"])
+    }
+    
+    func testDictionaryRepresentation_emptyProducts() {
+        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: [ButtonProduct(), ButtonProduct()])
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       [
+                        "name": "some name",
+                        "ifa": "some ifa",
+                        "products": [[:], [:]]]
+        )
+    }
+
+    func testDictionaryRepresentation_withProduct() {
+        let product = ButtonProduct()
+        product.id = "some id"
+        product.upc = "some upc"
+        product.categories = ["abc", "xyz"]
+        product.name = "some name"
+        product.currency = "USD"
+        product.value = 7
+        product.quantity = 25
+        product.url = "example.com"
+        product.attributes = ["a": "z", "b": "y"]
+        let body = ActivityRequestBody(ifa: "some ifa", name: "some name", products: [product])
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       [
+                        "name": "some name",
+                        "ifa": "some ifa",
+                        "products": [[
+                            "id": "some id",
+                            "upc": "some upc",
+                            "categories": ["abc", "xyz"],
+                            "name": "some name",
+                            "currency": "USD",
+                            "value": 7,
+                            "quantity": 25,
+                            "url": "example.com",
+                            "attributes": [
+                                "a": "z",
+                                "b": "y"
+                            ]]]]
+        )
+    }
+}

--- a/Tests/UnitTests/ActivityRequestBodyTests.swift
+++ b/Tests/UnitTests/ActivityRequestBodyTests.swift
@@ -39,27 +39,38 @@ class ActivityRequestBodyTests: XCTestCase {
     
     func testDictionaryRepresentation_noIFA() {
         let body = ActivityRequestBody(ifa: nil, attributionToken: nil, name: "some name", products: nil)
-        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name"])
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       ["activity_data": [
+                            "name": "some name"
+                        ]])
     }
     
     func testDictionaryRepresentation_withIFA() {
         let body = ActivityRequestBody(ifa: "some ifa", attributionToken: nil, name: "some name", products: nil)
-        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name", "ifa": "some ifa"])
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       ["ifa": "some ifa",
+                        "activity_data": [
+                            "name": "some name"
+                        ]])
     }
     
     func testDictionaryRepresentation_withAttributionToken() {
         let body = ActivityRequestBody(ifa: nil, attributionToken: "some srctok", name: "some name", products: nil)
-        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, ["name": "some name", "btn_ref": "some srctok"])
+        XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
+                       ["btn_ref": "some srctok",
+                        "activity_data": [
+                            "name": "some name"
+                        ]])
     }
     
     func testDictionaryRepresentation_emptyProducts() {
         let body = ActivityRequestBody(ifa: "some ifa", attributionToken: nil, name: "some name", products: [ButtonProduct(), ButtonProduct()])
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
-                       [
-                        "name": "some name",
-                        "ifa": "some ifa",
-                        "products": [[:], [:]]]
-        )
+                       ["ifa": "some ifa",
+                        "activity_data": [
+                           "name": "some name",
+                           "products": [[:], [:]]
+                       ]])
     }
 
     func testDictionaryRepresentation_withProduct() {
@@ -76,9 +87,10 @@ class ActivityRequestBodyTests: XCTestCase {
         let body = ActivityRequestBody(ifa: "some ifa", attributionToken: nil, name: "some name", products: [product])
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
                        [
-                        "name": "some name",
                         "ifa": "some ifa",
-                        "products": [[
+                        "activity_data": [
+                            "name": "some name",
+                            "products": [[
                             "id": "some id",
                             "upc": "some upc",
                             "categories": ["abc", "xyz"],
@@ -90,7 +102,8 @@ class ActivityRequestBodyTests: XCTestCase {
                             "attributes": [
                                 "a": "z",
                                 "b": "y"
-                            ]]]]
+                            ]]]
+                        ]]
         )
     }
 }

--- a/Tests/UnitTests/ApplicationIdTests.swift
+++ b/Tests/UnitTests/ApplicationIdTests.swift
@@ -31,7 +31,7 @@ class ApplicationIdTests: XCTestCase {
         XCTAssertEqual(ApplicationId("app-abc123")?.rawValue, "app-abc123")
     }
     
-    func testInit_invaidId_returnsNil() {
+    func testInit_invalidId_returnsNil() {
         XCTAssertNil(ApplicationId(""))
         XCTAssertNil(ApplicationId("abc123"))
         XCTAssertNil(ApplicationId("btn-123"))

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -34,7 +34,8 @@ class ButtonMerchantTests: XCTestCase {
         testCore = TestCore(buttonDefaults: defaults,
                             client: TestClient(session: TestURLSession(),
                                                userAgent: TestUserAgent(system: TestSystem()),
-                                               defaults: defaults),
+                                               defaults: defaults,
+                                               system: TestSystem()),
                             system: TestSystem(),
                             notificationCenter: TestNotificationCenter())
     }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -189,4 +189,54 @@ class ButtonMerchantTests: XCTestCase {
         // Assert
         XCTAssertTrue(ButtonMerchant.features.includesIFA)
     }
+    
+    func testActivity_returnsClient() {
+        ButtonMerchant._core = testCore
+        XCTAssertEqualReferences(ButtonMerchant.activity, testCore.client)
+    }
+    
+    func testActivity_productViewed_invokesClient() {
+        // Arrange
+        ButtonMerchant._core = testCore
+        let product = ButtonProduct()
+        product.name = "some name"
+        
+        // Act
+        ButtonMerchant.activity.productViewed(product)
+        
+        // Assert
+        let client = (testCore.client as? TestClient)!
+        XCTAssertTrue(client.didCallProductViewed)
+        XCTAssertEqual(client.actualProduct?.name, "some name")
+    }
+    
+    func testActivity_productAddedToCart_invokesClient() {
+        // Arrange
+        ButtonMerchant._core = testCore
+        let product = ButtonProduct()
+        product.name = "some name"
+        
+        // Act
+        ButtonMerchant.activity.productAddedToCard(product)
+        
+        // Assert
+        let client = (testCore.client as? TestClient)!
+        XCTAssertTrue(client.didCallProductAddedToCart)
+        XCTAssertEqual(client.actualProduct?.name, "some name")
+    }
+    
+    func testActivity_cartViewed_invokesClient() {
+        // Arrange
+        ButtonMerchant._core = testCore
+        let product = ButtonProduct()
+        product.name = "some name"
+        
+        // Act
+        ButtonMerchant.activity.cartViewed([product])
+        
+        // Assert
+        let client = (testCore.client as? TestClient)!
+        XCTAssertTrue(client.didCallCartViewed)
+        XCTAssertEqual(client.actualProducts?.first?.name, "some name")
+    }
 }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -218,7 +218,7 @@ class ButtonMerchantTests: XCTestCase {
         product.name = "some name"
         
         // Act
-        ButtonMerchant.activity.productAddedToCard(product)
+        ButtonMerchant.activity.productAddedToCart(product)
         
         // Assert
         let client = (testCore.client as? TestClient)!

--- a/Tests/UnitTests/ButtonProductTests.swift
+++ b/Tests/UnitTests/ButtonProductTests.swift
@@ -1,0 +1,43 @@
+//
+// ButtonProductTests.swift
+//
+// Copyright © 2020 Button, Inc. All rights reserved. (https://usebutton.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+	
+import XCTest
+@testable import ButtonMerchant
+
+class ButtonProductTests: XCTestCase {
+    
+    func testInitialization_createsInstance() {
+        let product = ButtonProduct()
+        XCTAssertNotNil(product)
+        XCTAssertNil(product.id)
+        XCTAssertNil(product.upc)
+        XCTAssertNil(product.categories)
+        XCTAssertNil(product.name)
+        XCTAssertNil(product.currency)
+        XCTAssertNil(product.url)
+        XCTAssertNil(product.attributes)
+        XCTAssertEqual(product.value, 0)
+        XCTAssertEqual(product.quantity, 0)
+    }
+}

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -725,8 +725,8 @@ class ClientTests: XCTestCase {
         XCTAssertEqual(task.originalRequest?.url?.absoluteString,
                        "https://app-abc123.mobileapi.usebutton.com/v1/app/activity")
         let json = try? JSONSerialization.jsonObject(with: task.originalRequest!.httpBody!) as? NSDictionary
-        XCTAssertEqual(json?["name"] as? String, "product-viewed")
         XCTAssertEqual(json?["ifa"] as? String, "some ifa")
+        XCTAssertEqual((json?["activity_data"] as? NSDictionary)?["name"] as? String, "product-viewed")
     }
     
     func testProductAddedToCart_enqueuesRequest() {
@@ -749,8 +749,8 @@ class ClientTests: XCTestCase {
         XCTAssertEqual(task.originalRequest?.url?.absoluteString,
                        "https://app-abc123.mobileapi.usebutton.com/v1/app/activity")
         let json = try? JSONSerialization.jsonObject(with: task.originalRequest!.httpBody!) as? NSDictionary
-        XCTAssertEqual(json?["name"] as? String, "add-to-cart")
         XCTAssertEqual(json?["ifa"] as? String, "some ifa")
+        XCTAssertEqual((json?["activity_data"] as? NSDictionary)?["name"] as? String, "add-to-cart")
     }
     
     func testCartViewed_enqueuesRequest() {
@@ -773,8 +773,8 @@ class ClientTests: XCTestCase {
         XCTAssertEqual(task.originalRequest?.url?.absoluteString,
                        "https://app-abc123.mobileapi.usebutton.com/v1/app/activity")
         let json = try? JSONSerialization.jsonObject(with: task.originalRequest!.httpBody!) as? NSDictionary
-        XCTAssertEqual(json?["name"] as? String, "cart-viewed")
         XCTAssertEqual(json?["ifa"] as? String, "some ifa")
+        XCTAssertEqual((json?["activity_data"] as? NSDictionary)?["name"] as? String, "cart-viewed")
     }
 }
 // swiftlint:enable file_length type_body_length

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -678,7 +678,7 @@ class ClientTests: XCTestCase {
         XCTAssertTrue(client.isConfigured)
     }
     
-    func testSetApplicationId_withPendingTasks_AttachedAppIdAndflushesPendingTasks() {
+    func testSetApplicationId_withPendingTasks_AttachedAppIdAndFlushesPendingTasks() {
         // Arrange
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession,
@@ -703,6 +703,78 @@ class ClientTests: XCTestCase {
             let json = try? JSONSerialization.jsonObject(with: task.originalRequest!.httpBody!) as? NSDictionary
             XCTAssertEqual(json?["application_id"] as? String, "app-test")
         }
+    }
+    
+    func testProductViewed_enqueuesRequest() {
+        // Arrange
+        let testURLSession = TestURLSession()
+        let testSystem = TestSystem()
+        testSystem.advertisingId = "some ifa"
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: testSystem)
+        client.applicationId = ApplicationId("app-abc123")
+        
+        // Act
+        client.productViewed(nil)
+        
+        // Assert
+        XCTAssertEqual(testURLSession.allDataTasks.count, 1)
+        let task = testURLSession.allDataTasks.first!
+        XCTAssertEqual(task.originalRequest?.url?.absoluteString,
+                       "https://app-abc123.mobileapi.usebutton.com/v1/app/activity")
+        let json = try? JSONSerialization.jsonObject(with: task.originalRequest!.httpBody!) as? NSDictionary
+        XCTAssertEqual(json?["name"] as? String, "product-viewed")
+        XCTAssertEqual(json?["ifa"] as? String, "some ifa")
+    }
+    
+    func testProductAddedToCart_enqueuesRequest() {
+        // Arrange
+        let testURLSession = TestURLSession()
+        let testSystem = TestSystem()
+        testSystem.advertisingId = "some ifa"
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: testSystem)
+        client.applicationId = ApplicationId("app-abc123")
+        
+        // Act
+        client.productAddedToCart(nil)
+        
+        // Assert
+        XCTAssertEqual(testURLSession.allDataTasks.count, 1)
+        let task = testURLSession.allDataTasks.first!
+        XCTAssertEqual(task.originalRequest?.url?.absoluteString,
+                       "https://app-abc123.mobileapi.usebutton.com/v1/app/activity")
+        let json = try? JSONSerialization.jsonObject(with: task.originalRequest!.httpBody!) as? NSDictionary
+        XCTAssertEqual(json?["name"] as? String, "add-to-cart")
+        XCTAssertEqual(json?["ifa"] as? String, "some ifa")
+    }
+    
+    func testCartViewed_enqueuesRequest() {
+        // Arrange
+        let testURLSession = TestURLSession()
+        let testSystem = TestSystem()
+        testSystem.advertisingId = "some ifa"
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: testSystem)
+        client.applicationId = ApplicationId("app-abc123")
+        
+        // Act
+        client.cartViewed(nil)
+        
+        // Assert
+        XCTAssertEqual(testURLSession.allDataTasks.count, 1)
+        let task = testURLSession.allDataTasks.first!
+        XCTAssertEqual(task.originalRequest?.url?.absoluteString,
+                       "https://app-abc123.mobileapi.usebutton.com/v1/app/activity")
+        let json = try? JSONSerialization.jsonObject(with: task.originalRequest!.httpBody!) as? NSDictionary
+        XCTAssertEqual(json?["name"] as? String, "cart-viewed")
+        XCTAssertEqual(json?["ifa"] as? String, "some ifa")
     }
 }
 // swiftlint:enable file_length type_body_length

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -25,7 +25,7 @@
 import XCTest
 @testable import ButtonMerchant
 
-// swiftlint:disable file_length
+// swiftlint:disable file_length type_body_length
 class ServiceTests: XCTestCase {
     
     let appId = ApplicationId("app-test")
@@ -57,7 +57,10 @@ class ClientTests: XCTestCase {
         let defaults = TestButtonDefaults(userDefaults: TestUserDefaults())
 
         // Act
-        let client = Client(session: expectedURLSession, userAgent: expectedUserAgent, defaults: defaults)
+        let client = Client(session: expectedURLSession,
+                            userAgent: expectedUserAgent,
+                            defaults: defaults,
+                            system: TestSystem())
 
         // Assert
         XCTAssertEqualReferences(client.session as AnyObject, expectedURLSession)
@@ -72,7 +75,10 @@ class ClientTests: XCTestCase {
         let testUserAgent = TestUserAgent()
         let expectedURL = URL(string: "https://usebutton.com")!
         let inputParameters = ["test": "test", "some": "value"]
-        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: TestURLSession(),
+                            userAgent: testUserAgent,
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         
         // Act
@@ -96,7 +102,10 @@ class ClientTests: XCTestCase {
         let testUserAgent = TestUserAgent()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         testDefaults.sessionId = "some-session-id"
-        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: testDefaults)
+        let client = Client(session: TestURLSession(),
+                            userAgent: testUserAgent,
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         
         // Act
@@ -114,7 +123,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let testUserAgent = TestUserAgent()
         let expectedURL = URL(string: "https://usebutton.com")!
-        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: TestURLSession(),
+                            userAgent: testUserAgent,
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         
         // Act
@@ -133,7 +145,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let testUserAgent = TestUserAgent()
         let expectedURL = URL(string: "https://usebutton.com")!
-        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: TestURLSession(),
+                            userAgent: testUserAgent,
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         
         // Act
         let request = client.urlRequest(url: expectedURL, parameters: nil)
@@ -152,7 +167,10 @@ class ClientTests: XCTestCase {
         let testUserAgent = TestUserAgent()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         testDefaults.sessionId = "some-session-id"
-        let client = Client(session: TestURLSession(), userAgent: testUserAgent, defaults: testDefaults)
+        let client = Client(session: TestURLSession(),
+                            userAgent: testUserAgent,
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
 
         // Act
@@ -167,7 +185,10 @@ class ClientTests: XCTestCase {
     func testEnqueueRequestCreatesDataTask() {
         // Arrange
         let testURLSession = TestURLSession()
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         
         // Act
@@ -184,7 +205,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "enqueue request success")
         let testURLSession = TestURLSession()
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         let expectedData = Data()
         
@@ -209,7 +233,10 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["session_id": "some-session-id"]])
         
@@ -234,7 +261,10 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         
         testDefaults.sessionId = "same-old-session"
@@ -261,7 +291,10 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         
         testDefaults.sessionId = "some-old-session"
@@ -288,7 +321,10 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "enqueue request success set session")
         let testURLSession = TestURLSession()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         
         let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["session_id": NSNull()]])
@@ -313,7 +349,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "enqueue request fails nil data")
         let testURLSession = TestURLSession()
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         let expectedError = TestError.known
         
@@ -337,7 +376,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "enqueue request fails bad response code")
         let testURLSession = TestURLSession()
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         let data = Data()
         let expectedError = TestError.known
@@ -363,7 +405,10 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "enqueue request completes on main")
         let testURLSession = TestURLSession()
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: testDefaults)
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         let url = URL(string: "https://usebutton.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
@@ -386,7 +431,10 @@ class ClientTests: XCTestCase {
     func testFetchPostInstallURLEnqueuesRequest() {
         // Arrange
         let testURLSession = TestURLSession()
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         let expectedURL = URL(string: "https://app-abc123.mobileapi.usebutton.com/v1/app/deferred-deeplink")!
 
@@ -409,7 +457,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "fetch post install url success")
         let testURLSession = TestURLSession()
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         let expectedURL = URL(string: "https://usebutton.com")!
         let expectedToken = "srctok-abc123"
@@ -437,7 +488,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "fetch post install url fails bad response")
         let testURLSession = TestURLSession()
-        let client = Client(session: testURLSession, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: testURLSession,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-test")
         let url = URL(string: "https://usebutton.com")!
         let responseDict = ["blargh": "blergh"]
@@ -463,7 +517,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "report order")
         let session = TestURLSession()
-        let client = Client(session: session, userAgent: TestUserAgent(), defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+        let client = Client(session: session,
+                            userAgent: TestUserAgent(),
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         let request = TestReportOrderRequest(parameters: ["foo": "bar"])
         
@@ -491,7 +548,10 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "report order persists session id")
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let client = Client(session: TestURLSession(), userAgent: TestUserAgent(), defaults: testDefaults)
+        let client = Client(session: TestURLSession(),
+                            userAgent: TestUserAgent(),
+                            defaults: testDefaults,
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         let request = TestReportOrderRequest(parameters: ["foo": "bar"])
         let responseData = try? JSONSerialization.data(withJSONObject: [ "meta": ["session_id": "some-session-id"]])
@@ -516,7 +576,8 @@ class ClientTests: XCTestCase {
         let testSession = TestURLSession()
         let client = Client(session: testSession,
                             userAgent: TestUserAgent(),
-                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         let event = AppEvent(name: "test-event", value: ["foo": "bar"], attributionToken: "some token")
         
@@ -554,7 +615,8 @@ class ClientTests: XCTestCase {
         let testSession = TestURLSession()
         let client = Client(session: testSession,
                             userAgent: TestUserAgent(),
-                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
         
         // Act
@@ -574,7 +636,8 @@ class ClientTests: XCTestCase {
         // Arrange
         let client = Client(session: TestURLSession(),
                             userAgent: TestUserAgent(),
-                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         let event = AppEvent(name: "event1", value: nil, attributionToken: "some token")
         
         // Act
@@ -591,7 +654,8 @@ class ClientTests: XCTestCase {
         // Arrange
         let client = Client(session: TestURLSession(),
                             userAgent: TestUserAgent(),
-                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         
         // Act
         client.applicationId = ApplicationId("app-test")
@@ -604,7 +668,8 @@ class ClientTests: XCTestCase {
         // Arrange
         let client = Client(session: TestURLSession(),
                             userAgent: TestUserAgent(),
-                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         
         // Act
         client.applicationId = ApplicationId("bad id") // Note: we allow bad requests if configure has been called.
@@ -618,7 +683,8 @@ class ClientTests: XCTestCase {
         let testURLSession = TestURLSession()
         let client = Client(session: testURLSession,
                             userAgent: TestUserAgent(),
-                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+                            defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                            system: TestSystem())
         let event = AppEvent(name: "event1", value: nil, attributionToken: "some token")
         client.fetchPostInstallURL(parameters: ["foo": "bar"]) { _, _  in }
         client.reportEvents([event], ifa: "some ifa") { _ in }
@@ -639,4 +705,4 @@ class ClientTests: XCTestCase {
         }
     }
 }
-// swiftlint:enable file_length
+// swiftlint:enable file_length type_body_length

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -33,7 +33,8 @@ class CoreTests: XCTestCase {
     override func setUp() {
         testClient = TestClient(session: TestURLSession(),
                                 userAgent: TestUserAgent(system: TestSystem()),
-                                defaults: TestButtonDefaults(userDefaults: TestUserDefaults()))
+                                defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
+                                system: TestSystem())
     }
     
     func testInitialization() {

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -34,6 +34,9 @@ class TestClient: ClientType {
     var didCallTrackOrder = false
     var didCallReportOrder = false
     var didCallReportEvents = false
+    var didCallProductViewed = false
+    var didCallProductAddedToCart = false
+    var didCallCartViewed = false
 
     var isConfigured: Bool = true
     var applicationId: ApplicationId?
@@ -50,6 +53,8 @@ class TestClient: ClientType {
     var actualEvents: [AppEvent]?
     var actualIFA: String?
     var actualReportEventsCompletion: ((Error?) -> Void)?
+    var actualProduct: ButtonProductCompatible?
+    var actualProducts: [ButtonProductCompatible]?
     
     required init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType) {
         self.session = session
@@ -81,5 +86,20 @@ class TestClient: ClientType {
         actualEvents = events
         actualIFA = ifa
         actualReportEventsCompletion = completion
+    }
+    
+    func productViewed(_ product: ButtonProductCompatible?) {
+        didCallProductViewed = true
+        actualProduct = product
+    }
+    
+    func productAddedToCard(_ product: ButtonProductCompatible?) {
+        didCallProductAddedToCart = true
+        actualProduct = product
+    }
+    
+    func cartViewed(_ products: [ButtonProductCompatible]?) {
+        didCallCartViewed = true
+        actualProducts = products
     }
 }

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -95,7 +95,7 @@ class TestClient: ClientType {
         actualProduct = product
     }
     
-    func productAddedToCard(_ product: ButtonProductCompatible?) {
+    func productAddedToCart(_ product: ButtonProductCompatible?) {
         didCallProductAddedToCart = true
         actualProduct = product
     }

--- a/Tests/UnitTests/TestObjects/TestClient.swift
+++ b/Tests/UnitTests/TestObjects/TestClient.swift
@@ -44,6 +44,7 @@ class TestClient: ClientType {
     var session: URLSessionType
     var userAgent: UserAgentType
     var defaults: ButtonDefaultsType
+    var system: SystemType
     var pendingTasks = [PendingTask]()
 
     var postInstallCompletion: ((URL?, String?) -> Void)?
@@ -56,10 +57,11 @@ class TestClient: ClientType {
     var actualProduct: ButtonProductCompatible?
     var actualProducts: [ButtonProductCompatible]?
     
-    required init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType) {
+    required init(session: URLSessionType, userAgent: UserAgentType, defaults: ButtonDefaultsType, system: SystemType) {
         self.session = session
         self.userAgent = userAgent
         self.defaults = defaults
+        self.system = system
         self.testParameters = [:]
     }
     


### PR DESCRIPTION
### Goals :dart:
To allow a Brand to report key points of a user's shopping journey within their application.

### Implementation Details :construction:
- API is available via a "module" -- `ButtonMerchant.activity.xxxxx()`
- If an _empty_ `ButtonProduct` is provided then it will still be reported as an empty JSON object. For example, if a cart has been viewed with two products then it'll be reported like so:
```
{
	"name": "cart-viewed",
	"products": [{}, {}]
}
```

