### PR TITLE
Update event request fields

### DIFF
--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -123,7 +123,7 @@
 		FB5AA6AD24D0A19B0057F3A0 /* ApplicationIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5AA6AC24D0A19B0057F3A0 /* ApplicationIdTests.swift */; };
 		FB5AA6AE24D0BADD0057F3A0 /* ApplicationId.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5AA6AA24D0A11D0057F3A0 /* ApplicationId.swift */; };
 		FB70030824CF2FDE0050E021 /* AppEventsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70030724CF2FDE0050E021 /* AppEventsRequestBody.swift */; };
-		FB70030B24CF46260050E021 /* AppEventRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70030924CF44620050E021 /* AppEventRequestBodyTests.swift */; };
+		FB70030B24CF46260050E021 /* AppEventsRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70030924CF44620050E021 /* AppEventsRequestBodyTests.swift */; };
 		FB70030F24CF48A90050E021 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70030E24CF48A90050E021 /* AppEvent.swift */; };
 		FB70031224CF4BDE0050E021 /* AppEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70031024CF4BC60050E021 /* AppEventTests.swift */; };
 		FB70031424CF5EA50050E021 /* String+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70031324CF5EA50050E021 /* String+Error.swift */; };
@@ -284,7 +284,7 @@
 		FB5AA6AA24D0A11D0057F3A0 /* ApplicationId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationId.swift; sourceTree = "<group>"; };
 		FB5AA6AC24D0A19B0057F3A0 /* ApplicationIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationIdTests.swift; sourceTree = "<group>"; };
 		FB70030724CF2FDE0050E021 /* AppEventsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventsRequestBody.swift; sourceTree = "<group>"; };
-		FB70030924CF44620050E021 /* AppEventRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventRequestBodyTests.swift; sourceTree = "<group>"; };
+		FB70030924CF44620050E021 /* AppEventsRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventsRequestBodyTests.swift; sourceTree = "<group>"; };
 		FB70030E24CF48A90050E021 /* AppEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEvent.swift; sourceTree = "<group>"; };
 		FB70031024CF4BC60050E021 /* AppEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventTests.swift; sourceTree = "<group>"; };
 		FB70031324CF5EA50050E021 /* String+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Error.swift"; sourceTree = "<group>"; };
@@ -1211,7 +1211,7 @@
 				DE1706E920856417009FF30B /* TestAdIdManager.swift in Sources */,
 				DA29D892209CDC3100537806 /* URLSessionTests.swift in Sources */,
 				DA756B7922B2DB67003397E3 /* SessionDelegateTests.swift in Sources */,
-				FB70030B24CF46260050E021 /* AppEventRequestBodyTests.swift in Sources */,
+				FB70030B24CF46260050E021 /* AppEventsRequestBodyTests.swift in Sources */,
 				9E4C496820616B040053E4CA /* ButtonDefaultsTests.swift in Sources */,
 				DAD885D124E41B4100E138BF /* ActivityRequestBodyTests.swift in Sources */,
 				9E6F4341206C160C004242A1 /* TestClient.swift in Sources */,

--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -58,6 +58,11 @@ https://developer.usebutton.com/guides/merchants/ios/button-merchant-integration
                 NSLog("Post install: %@", url.absoluteString)
             }
         }
+        let date = Date()
+        print(date.ISO8601String)
+        print(date.eventISO8601String)
+//        print(Date.eventDateFrom(date.eventISO8601String))
+        print(Date.eventDateFrom(date.eventISO8601String)!.eventISO8601String)
 
         controller?.navigationItem.prompt = "Application ID: \(yourApplicationId)"
 

--- a/Source/AppEvent.swift
+++ b/Source/AppEvent.swift
@@ -28,9 +28,11 @@ internal struct AppEvent: Codable {
     let name: String
     let value: [String: String]?
     let attributionToken: String?
+    let time: String
+    let uuid: String
     
     enum CodingKeys: String, CodingKey {
-        case name, value
+        case name, value, time, uuid
         case attributionToken = "promotion_source_token"
     }
 }

--- a/Source/AppEventsRequestBody.swift
+++ b/Source/AppEventsRequestBody.swift
@@ -27,4 +27,10 @@ import Foundation
 internal struct AppEventsRequestBody: Codable {
     let ifa: String?
     let events: [AppEvent]
+    let currentTime: String
+    
+    enum CodingKeys: String, CodingKey {
+        case ifa, events
+        case currentTime = "current_time"
+    }
 }

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -118,7 +118,7 @@ internal final class Client: ClientType {
             }
             return
         }
-        let body = AppEventsRequestBody(ifa: ifa, events: events)
+        let body = AppEventsRequestBody(ifa: ifa, events: events, currentTime: system.currentDate.eventISO8601String)
         let request = urlRequest(url: Service.appEvents.urlWith(applicationId), parameters: body.dictionaryRepresentation)
         enqueueRequest(request: request) { _, error in
             if let completion = completion {

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -129,7 +129,9 @@ final internal class Core: CoreType {
         
         let event = AppEvent(name: "btn:deeplink-opened",
                              value: [ "url": filteredURL.absoluteString],
-                             attributionToken: incomingToken)
+                             attributionToken: incomingToken,
+                             time: system.currentDate.eventISO8601String,
+                             uuid: UUID().uuidString)
         client.reportEvents([event], ifa: system.advertisingId, nil)
     }
     

--- a/Source/Extensions/DateExtensions.swift
+++ b/Source/Extensions/DateExtensions.swift
@@ -32,7 +32,22 @@ internal extension Date {
         return formatter
     }()
     
+    static let eventISO8601Formatter = { () -> DateFormatter in
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+        return formatter
+    }()
+    
     var ISO8601String: String {
         return Date.ISO8601Formatter.string(from: self)
+    }
+    
+    var eventISO8601String: String {
+        return Date.eventISO8601Formatter.string(from: self)
+    }
+    
+    static func eventDateFrom(_ string: String) -> Date? {
+        return Date.eventISO8601Formatter.date(from: string)
     }
 }

--- a/Source/Extensions/DateExtensions.swift
+++ b/Source/Extensions/DateExtensions.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-internal extension Date {
+public extension Date {
 
     static let ISO8601Formatter = { () -> DateFormatter in
         let formatter = DateFormatter()

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -60,3 +60,11 @@ public extension String {
         return self.range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil
     }
 }
+
+internal extension String {
+    static let ISO8601Formatter = { () -> DateFormatter in
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        return formatter
+    }()
+}

--- a/Tests/UnitTests/AppEventTests.swift
+++ b/Tests/UnitTests/AppEventTests.swift
@@ -28,34 +28,42 @@ import XCTest
 class AppEventTests: XCTestCase {
 
     func testInitialization_createsInstance() {
-        let event = AppEvent(name: "test event", value: ["foo": "bar"], attributionToken: "some token")
+        let event = AppEvent(name: "test event", value: ["foo": "bar"], attributionToken: "some token", time: "some time", uuid: "some uuid")
         XCTAssertEqual(event.name, "test event")
         XCTAssertEqual(event.value, ["foo": "bar"])
         XCTAssertEqual(event.attributionToken, "some token")
+        XCTAssertEqual(event.time, "some time")
+        XCTAssertEqual(event.uuid, "some uuid")
     }
     
     func testSerialization_createsDictionary() {
-        let event = AppEvent(name: "test event", value: ["foo": "bar"], attributionToken: "some token")
+        let event = AppEvent(name: "test event", value: ["foo": "bar"], attributionToken: "some token", time: "some time", uuid: "some uuid")
         XCTAssertEqual(event.dictionaryRepresentation as NSDictionary, [
             "name": "test event",
             "value": ["foo": "bar"],
-            "promotion_source_token": "some token"
+            "promotion_source_token": "some token",
+            "time": "some time",
+            "uuid": "some uuid"
         ])
     }
     
     func testMissingValue_omitsValue() {
-        let event = AppEvent(name: "test event", value: nil, attributionToken: "some token")
+        let event = AppEvent(name: "test event", value: nil, attributionToken: "some token", time: "some time", uuid: "some uuid")
         XCTAssertEqual(event.dictionaryRepresentation as NSDictionary, [
             "name": "test event",
-            "promotion_source_token": "some token"
+            "promotion_source_token": "some token",
+            "time": "some time",
+            "uuid": "some uuid"
         ])
     }
     
     func testMissingSourceToken_omitsSourceToken() {
-        let event = AppEvent(name: "test event", value: ["foo": "bar"], attributionToken: nil)
+        let event = AppEvent(name: "test event", value: ["foo": "bar"], attributionToken: nil, time: "some time", uuid: "some uuid")
         XCTAssertEqual(event.dictionaryRepresentation as NSDictionary, [
             "name": "test event",
-            "value": ["foo": "bar"]
+            "value": ["foo": "bar"],
+            "time": "some time",
+            "uuid": "some uuid"
         ])
     }
 }

--- a/Tests/UnitTests/AppEventsRequestBodyTests.swift
+++ b/Tests/UnitTests/AppEventsRequestBodyTests.swift
@@ -1,5 +1,5 @@
 //
-// AppEventRequestBodyTests.swift
+// AppEventsRequestBodyTests.swift
 //
 // Copyright © 2020 Button, Inc. All rights reserved. (https://usebutton.com)
 //
@@ -30,7 +30,9 @@ class AppEventsRequestBodyTests: XCTestCase {
     func testInitialization_createsInstance() {
         let event = AppEvent(name: "test-event",
                              value: ["url": "https://example.com"],
-                             attributionToken: "some token")
+                             attributionToken: "some token",
+                             time: "2020-04-23T11:30:02.844-04:00",
+                             uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
         let body = AppEventsRequestBody(ifa: "some ifa", events: [event])
         
         XCTAssertEqual(body.ifa, "some ifa")
@@ -38,12 +40,16 @@ class AppEventsRequestBodyTests: XCTestCase {
         XCTAssertEqual(body.events.first?.name, "test-event")
         XCTAssertEqual(body.events.first?.value, ["url": "https://example.com"])
         XCTAssertEqual(body.events.first?.attributionToken, "some token")
+        XCTAssertEqual(body.events.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(body.events.first?.uuid, "3b3024dc-e56f-412e-8015-5c2c308126fd")
     }
     
     func testSerialization_createsDisctionary() {
         let event = AppEvent(name: "test-event",
                              value: ["url": "https://example.com"],
-                             attributionToken: "some token")
+                             attributionToken: "some token",
+                             time: "2020-04-23T11:30:02.844-04:00",
+                             uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
         let body = AppEventsRequestBody(ifa: "some ifa", events: [event])
         
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
@@ -53,7 +59,9 @@ class AppEventsRequestBodyTests: XCTestCase {
                             [
                                 "name": "test-event",
                                 "value": ["url": "https://example.com"],
-                                "promotion_source_token": "some token"
+                                "promotion_source_token": "some token",
+                                "time": "2020-04-23T11:30:02.844-04:00",
+                                "uuid": "3b3024dc-e56f-412e-8015-5c2c308126fd"
                             ]
                         ]])
     }
@@ -61,7 +69,9 @@ class AppEventsRequestBodyTests: XCTestCase {
     func testMissingIFA_omitsIFA() {
         let event = AppEvent(name: "test-event",
                              value: ["url": "https://example.com"],
-                             attributionToken: "some token")
+                             attributionToken: "some token",
+                             time: "2020-04-23T11:30:02.844-04:00",
+                             uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
         let body = AppEventsRequestBody(ifa: nil, events: [event])
         
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
@@ -70,7 +80,9 @@ class AppEventsRequestBodyTests: XCTestCase {
                             [
                                 "name": "test-event",
                                 "value": ["url": "https://example.com"],
-                                "promotion_source_token": "some token"
+                                "promotion_source_token": "some token",
+                                "time": "2020-04-23T11:30:02.844-04:00",
+                                "uuid": "3b3024dc-e56f-412e-8015-5c2c308126fd"
                             ]
                         ]])
     }

--- a/Tests/UnitTests/AppEventsRequestBodyTests.swift
+++ b/Tests/UnitTests/AppEventsRequestBodyTests.swift
@@ -33,9 +33,10 @@ class AppEventsRequestBodyTests: XCTestCase {
                              attributionToken: "some token",
                              time: "2020-04-23T11:30:02.844-04:00",
                              uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
-        let body = AppEventsRequestBody(ifa: "some ifa", events: [event])
+        let body = AppEventsRequestBody(ifa: "some ifa", events: [event], currentTime: "some time")
         
         XCTAssertEqual(body.ifa, "some ifa")
+        XCTAssertEqual(body.currentTime, "some time")
         XCTAssertEqual(body.events.count, 1)
         XCTAssertEqual(body.events.first?.name, "test-event")
         XCTAssertEqual(body.events.first?.value, ["url": "https://example.com"])
@@ -50,11 +51,12 @@ class AppEventsRequestBodyTests: XCTestCase {
                              attributionToken: "some token",
                              time: "2020-04-23T11:30:02.844-04:00",
                              uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
-        let body = AppEventsRequestBody(ifa: "some ifa", events: [event])
+        let body = AppEventsRequestBody(ifa: "some ifa", events: [event], currentTime: "some time")
         
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
                        [
                         "ifa": "some ifa",
+                        "current_time": "some time",
                         "events": [
                             [
                                 "name": "test-event",
@@ -72,10 +74,11 @@ class AppEventsRequestBodyTests: XCTestCase {
                              attributionToken: "some token",
                              time: "2020-04-23T11:30:02.844-04:00",
                              uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
-        let body = AppEventsRequestBody(ifa: nil, events: [event])
+        let body = AppEventsRequestBody(ifa: nil, events: [event], currentTime: "some time")
         
         XCTAssertEqual(body.dictionaryRepresentation as NSDictionary,
                        [
+                        "current_time": "some time",
                         "events": [
                             [
                                 "name": "test-event",

--- a/Tests/UnitTests/AppEventsRequestBodyTests.swift
+++ b/Tests/UnitTests/AppEventsRequestBodyTests.swift
@@ -31,7 +31,7 @@ class AppEventsRequestBodyTests: XCTestCase {
         let event = AppEvent(name: "test-event",
                              value: ["url": "https://example.com"],
                              attributionToken: "some token",
-                             time: "2020-04-23T11:30:02.844-04:00",
+                             time: "2019-07-25T21:30:02.844Z",
                              uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
         let body = AppEventsRequestBody(ifa: "some ifa", events: [event], currentTime: "some time")
         
@@ -41,7 +41,7 @@ class AppEventsRequestBodyTests: XCTestCase {
         XCTAssertEqual(body.events.first?.name, "test-event")
         XCTAssertEqual(body.events.first?.value, ["url": "https://example.com"])
         XCTAssertEqual(body.events.first?.attributionToken, "some token")
-        XCTAssertEqual(body.events.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(body.events.first?.time, "2019-07-25T21:30:02.844Z")
         XCTAssertEqual(body.events.first?.uuid, "3b3024dc-e56f-412e-8015-5c2c308126fd")
     }
     
@@ -49,7 +49,7 @@ class AppEventsRequestBodyTests: XCTestCase {
         let event = AppEvent(name: "test-event",
                              value: ["url": "https://example.com"],
                              attributionToken: "some token",
-                             time: "2020-04-23T11:30:02.844-04:00",
+                             time: "2019-07-25T21:30:02.844Z",
                              uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
         let body = AppEventsRequestBody(ifa: "some ifa", events: [event], currentTime: "some time")
         
@@ -62,7 +62,7 @@ class AppEventsRequestBodyTests: XCTestCase {
                                 "name": "test-event",
                                 "value": ["url": "https://example.com"],
                                 "promotion_source_token": "some token",
-                                "time": "2020-04-23T11:30:02.844-04:00",
+                                "time": "2019-07-25T21:30:02.844Z",
                                 "uuid": "3b3024dc-e56f-412e-8015-5c2c308126fd"
                             ]
                         ]])
@@ -72,7 +72,7 @@ class AppEventsRequestBodyTests: XCTestCase {
         let event = AppEvent(name: "test-event",
                              value: ["url": "https://example.com"],
                              attributionToken: "some token",
-                             time: "2020-04-23T11:30:02.844-04:00",
+                             time: "2019-07-25T21:30:02.844Z",
                              uuid: "3b3024dc-e56f-412e-8015-5c2c308126fd")
         let body = AppEventsRequestBody(ifa: nil, events: [event], currentTime: "some time")
         
@@ -84,7 +84,7 @@ class AppEventsRequestBodyTests: XCTestCase {
                                 "name": "test-event",
                                 "value": ["url": "https://example.com"],
                                 "promotion_source_token": "some token",
-                                "time": "2020-04-23T11:30:02.844-04:00",
+                                "time": "2019-07-25T21:30:02.844Z",
                                 "uuid": "3b3024dc-e56f-412e-8015-5c2c308126fd"
                             ]
                         ]])

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -579,7 +579,7 @@ class ClientTests: XCTestCase {
                             defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
                             system: TestSystem())
         client.applicationId = ApplicationId("app-abc123")
-        let event = AppEvent(name: "test-event", value: ["foo": "bar"], attributionToken: "some token")
+        let event = AppEvent(name: "test-event", value: ["foo": "bar"], attributionToken: "some token", time: "some time", uuid: "some uuid")
         
         // Act
         client.reportEvents([event], ifa: "some ifa") { error in
@@ -595,7 +595,9 @@ class ClientTests: XCTestCase {
                     [
                         "name": "test-event",
                         "value": ["foo": "bar"],
-                        "promotion_source_token": "some token"
+                        "promotion_source_token": "some token",
+                        "time": "some time",
+                        "uuid": "some uuid"
                     ]
                 ]])
             
@@ -638,7 +640,7 @@ class ClientTests: XCTestCase {
                             userAgent: TestUserAgent(),
                             defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
                             system: TestSystem())
-        let event = AppEvent(name: "event1", value: nil, attributionToken: "some token")
+        let event = AppEvent(name: "event1", value: nil, attributionToken: "some token", time: "some time", uuid: "some uuid")
         
         // Act
         client.fetchPostInstallURL(parameters: [:]) { _, _  in }
@@ -685,7 +687,7 @@ class ClientTests: XCTestCase {
                             userAgent: TestUserAgent(),
                             defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
                             system: TestSystem())
-        let event = AppEvent(name: "event1", value: nil, attributionToken: "some token")
+        let event = AppEvent(name: "event1", value: nil, attributionToken: "some token", time: "some time", uuid: "some uuid")
         client.fetchPostInstallURL(parameters: ["foo": "bar"]) { _, _  in }
         client.reportEvents([event], ifa: "some ifa") { _ in }
         

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -575,7 +575,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "report events succeeds")
         let testSession = TestURLSession()
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let client = Client(session: testSession,
                             userAgent: TestUserAgent(),
                             defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
@@ -593,7 +593,7 @@ class ClientTests: XCTestCase {
             XCTAssertEqual(request?.url?.absoluteString, "https://app-abc123.mobileapi.usebutton.com/v1/app/events")
             XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, [
                 "ifa": "some ifa",
-                "current_time": "2020-04-23T11:30:02.844-04:00",
+                "current_time": "2019-07-25T21:30:02.844Z",
                 "events": [
                     [
                         "name": "test-event",

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -574,10 +574,12 @@ class ClientTests: XCTestCase {
         // Arrange
         let expectation = XCTestExpectation(description: "report events succeeds")
         let testSession = TestURLSession()
+        let testSystem = TestSystem()
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let client = Client(session: testSession,
                             userAgent: TestUserAgent(),
                             defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
-                            system: TestSystem())
+                            system: testSystem)
         client.applicationId = ApplicationId("app-abc123")
         let event = AppEvent(name: "test-event", value: ["foo": "bar"], attributionToken: "some token", time: "some time", uuid: "some uuid")
         
@@ -591,6 +593,7 @@ class ClientTests: XCTestCase {
             XCTAssertEqual(request?.url?.absoluteString, "https://app-abc123.mobileapi.usebutton.com/v1/app/events")
             XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, [
                 "ifa": "some ifa",
+                "current_time": "2020-04-23T11:30:02.844-04:00",
                 "events": [
                     [
                         "name": "test-event",

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -129,6 +129,7 @@ class CoreTests: XCTestCase {
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
         testSystem.advertisingId = "some ifa"
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -144,16 +145,21 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
+        XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withoutToken_tracksDeeplinkOpened() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let url = URL(string: "http://usebutton.com/no-token")!
+        let testSystem = TestSystem()
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: TestSystem(),
+                        system: testSystem,
                         notificationCenter: TestNotificationCenter())
+        let url = URL(string: "http://usebutton.com/no-token")!
 
         // Act
         core.trackIncomingURL(url)
@@ -163,16 +169,21 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
+        XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withBTNParams_tracksDeeplinkOpened() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let url = URL(string: "http://usebutton.com/no-token/?btn_1=1&btn_2=2&btn_ref=faketok-123")!
+        let testSystem = TestSystem()
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: TestSystem(),
+                        system: testSystem,
                         notificationCenter: TestNotificationCenter())
+        let url = URL(string: "http://usebutton.com/no-token/?btn_1=1&btn_2=2&btn_ref=faketok-123")!
 
         // Act
         core.trackIncomingURL(url)
@@ -182,16 +193,21 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
+        XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withFromLandingFromTrackingParams_tracksDeeplinkOpened() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let url = URL(string: "http://usebutton.com/no-token/?from_landing=true&from_tracking=false")!
+        let testSystem = TestSystem()
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: TestSystem(),
+                        system: testSystem,
                         notificationCenter: TestNotificationCenter())
+        let url = URL(string: "http://usebutton.com/no-token/?from_landing=true&from_tracking=false")!
 
         // Act
         core.trackIncomingURL(url)
@@ -201,16 +217,21 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
+        XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withoutButtonParams_tracksNoParams() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let url = URL(string: "http://usebutton.com/no-token/?not_ours=param&also_not=same&utm_campaign=nope")!
+        let testSystem = TestSystem()
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: TestSystem(),
+                        system: testSystem,
                         notificationCenter: TestNotificationCenter())
+        let url = URL(string: "http://usebutton.com/no-token/?not_ours=param&also_not=same&utm_campaign=nope")!
 
         // Act
         core.trackIncomingURL(url)
@@ -220,16 +241,21 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
+        XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withMixedParams_tracksWithButtonParams() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let url = URL(string: "http://usebutton.com/no-token/?theirs=param&from_landing=1&btn_test=0")!
+        let testSystem = TestSystem()
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: TestSystem(),
+                        system: testSystem,
                         notificationCenter: TestNotificationCenter())
+        let url = URL(string: "http://usebutton.com/no-token/?theirs=param&from_landing=1&btn_test=0")!
 
         // Act
         core.trackIncomingURL(url)
@@ -239,16 +265,21 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?from_landing=1&btn_test=0")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
+        XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withMixedCase_tracksWithButtonParams() {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
-        let url = URL(string: "http://usebutton.com/no-token/?theirs=param&From_landing=1&Btn_test=0")!
+        let testSystem = TestSystem()
+        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
-                        system: TestSystem(),
+                        system: testSystem,
                         notificationCenter: TestNotificationCenter())
+        let url = URL(string: "http://usebutton.com/no-token/?theirs=param&From_landing=1&Btn_test=0")!
 
         // Act
         core.trackIncomingURL(url)
@@ -258,6 +289,9 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?From_landing=1&Btn_test=0")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
+        XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURLPostsNotification() {

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -129,7 +129,7 @@ class CoreTests: XCTestCase {
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
         testSystem.advertisingId = "some ifa"
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -145,7 +145,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
@@ -154,7 +154,7 @@ class CoreTests: XCTestCase {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -169,7 +169,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
@@ -178,7 +178,7 @@ class CoreTests: XCTestCase {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -193,7 +193,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
@@ -202,7 +202,7 @@ class CoreTests: XCTestCase {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -217,7 +217,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
@@ -226,7 +226,7 @@ class CoreTests: XCTestCase {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -241,7 +241,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?")
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
@@ -250,7 +250,7 @@ class CoreTests: XCTestCase {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -265,7 +265,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?from_landing=1&btn_test=0")
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
@@ -274,7 +274,7 @@ class CoreTests: XCTestCase {
         // Arrange
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2020-04-23T11:30:02.844-04:00")!
+        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
@@ -289,7 +289,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?From_landing=1&Btn_test=0")
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2020-04-23T11:30:02.844-04:00")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }

--- a/Tests/UnitTests/TestObjects/TestSystem.swift
+++ b/Tests/UnitTests/TestObjects/TestSystem.swift
@@ -63,6 +63,7 @@ final class TestSystem: SystemType {
 
         // Fix timezone to UTC for tests.
         Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
+        Date.eventISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
         testCurrentDate = Date.ISO8601Formatter.date(from: "2018-01-23T12:00:00Z")!
         
         self.fileManager = fileManager


### PR DESCRIPTION
### Goals :dart:
Fix the payload sent in the `POST /v1/app/events` request:
- Include `current_time` at the top level
- Include `time` with each event
- Include `uuid` with each event