### PR TITLE
Notify on attribution token update from deferred deeplink

### DIFF
--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -177,7 +177,7 @@ final internal class Core: CoreType {
                     completion(nil, nil)
                     return
             }
-            self?.buttonDefaults.attributionToken = token
+            self?.updateAttributionIfNeeded(token: token)
             completion(url, nil)
         }
     }

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -360,10 +360,11 @@ class CoreTests: XCTestCase {
         let expectation = XCTestExpectation(description: "handle post install url")
         let testDefaults = TestButtonDefaults(userDefaults: TestUserDefaults())
         let testSystem = TestSystem()
+        let testNotificationCenter = TestNotificationCenter()
         let core = Core(buttonDefaults: testDefaults,
                         client: testClient,
                         system: testSystem,
-                        notificationCenter: TestNotificationCenter())
+                        notificationCenter: testNotificationCenter)
         testDefaults.testHasFetchedPostInstallURL = false
         testSystem.testIsNewInstall = true
         core.applicationId = ApplicationId("app-123")
@@ -378,6 +379,13 @@ class CoreTests: XCTestCase {
             XCTAssertTrue(testDefaults.didStoreToken)
             XCTAssertNotNil(testDefaults.attributionToken)
             XCTAssertEqual(testDefaults.attributionToken, expectedToken)
+            XCTAssertEqual(core.attributionToken, expectedToken)
+            XCTAssertTrue(testNotificationCenter.didCallPostNotification)
+            XCTAssertNil(testNotificationCenter.testObject)
+            XCTAssertEqual(testNotificationCenter.testNotificationName,
+                           Notification.Name.Button.AttributionTokenDidChange)
+            XCTAssertEqual(testNotificationCenter.testUserInfo! as NSDictionary,
+                           [Notification.Key.NewToken: expectedToken])
             expectation.fulfill()
         }
         XCTAssertEqual(testClient.testParameters as NSDictionary,


### PR DESCRIPTION
### Goals :dart:
Previously, when an attribution token was returned in the response of the `/v1/app/deferred-deeplink` request, it was written to disk only. This PR changes that logic to
- Store the token in memory
- Post a notification indicating that the token has been changed