### PR TITLE
Replace String: Error with internally defined errors (fixes #77)

### DIFF
--- a/ButtonMerchant.xcodeproj/project.pbxproj
+++ b/ButtonMerchant.xcodeproj/project.pbxproj
@@ -124,7 +124,7 @@
 		FB70030B24CF46260050E021 /* AppEventsRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70030924CF44620050E021 /* AppEventsRequestBodyTests.swift */; };
 		FB70030F24CF48A90050E021 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70030E24CF48A90050E021 /* AppEvent.swift */; };
 		FB70031224CF4BDE0050E021 /* AppEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70031024CF4BC60050E021 /* AppEventTests.swift */; };
-		FB70031424CF5EA50050E021 /* String+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB70031324CF5EA50050E021 /* String+Error.swift */; };
+		FBEBC99625437E1700AAE9E5 /* ButtonMerchantError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBEBC99525437E1700AAE9E5 /* ButtonMerchantError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -284,7 +284,7 @@
 		FB70030924CF44620050E021 /* AppEventsRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventsRequestBodyTests.swift; sourceTree = "<group>"; };
 		FB70030E24CF48A90050E021 /* AppEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEvent.swift; sourceTree = "<group>"; };
 		FB70031024CF4BC60050E021 /* AppEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventTests.swift; sourceTree = "<group>"; };
-		FB70031324CF5EA50050E021 /* String+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Error.swift"; sourceTree = "<group>"; };
+		FBEBC99525437E1700AAE9E5 /* ButtonMerchantError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonMerchantError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -483,7 +483,6 @@
 				DA756B8222B33762003397E3 /* URLAuthenticationChallengeExtensions.swift */,
 				DA756B8422B3378B003397E3 /* URLProtectionSpaceExtensions.swift */,
 				9E56CE5822B8049C00E75884 /* StringExtensions.swift */,
-				FB70031324CF5EA50050E021 /* String+Error.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -613,6 +612,7 @@
 			children = (
 				DE175A1920A09BB1005C97B9 /* Version */,
 				DE865F792052F90600F4054D /* ButtonMerchant.swift */,
+				FBEBC99525437E1700AAE9E5 /* ButtonMerchantError.swift */,
 				DC1F008022CA85F000E789D0 /* Configurable.swift */,
 				DCF4AD0322B421FB000DA3B2 /* ReportOrderBody.swift */,
 				DA0FA29F205C1B3A008296A6 /* Core.swift */,
@@ -1113,7 +1113,6 @@
 				DE175A1C20A09DEA005C97B9 /* Version.generated.swift in Sources */,
 				9EB1B0A0207AB43E00BE0A1A /* System.swift in Sources */,
 				DAE8B96F22AF5F0700D11AF9 /* TrustEvaluator.swift in Sources */,
-				FB70031424CF5EA50050E021 /* String+Error.swift in Sources */,
 				DE2F7450208F6552001E4BD6 /* ConfigurationError.swift in Sources */,
 				DCF4AD0422B421FB000DA3B2 /* ReportOrderBody.swift in Sources */,
 				FB70030F24CF48A90050E021 /* AppEvent.swift in Sources */,
@@ -1121,6 +1120,7 @@
 				DE865FA620530BCE00F4054D /* ButtonMerchant.swift in Sources */,
 				9E56CE5A22B812AE00E75884 /* StringExtensions.swift in Sources */,
 				9E2B4317206C1335009F2886 /* EncodableExtensions.swift in Sources */,
+				FBEBC99625437E1700AAE9E5 /* ButtonMerchantError.swift in Sources */,
 				9E2B431B206C134A009F2886 /* PostInstallBody.swift in Sources */,
 				9EB1B0A4207AB68100BE0A1A /* CalendarExtensions.swift in Sources */,
 				DE1706DB20855B06009FF30B /* UIDeviceExtensions.swift in Sources */,

--- a/Source/ButtonMerchant.swift
+++ b/Source/ButtonMerchant.swift
@@ -210,6 +210,6 @@ extension ButtonMerchant {
         guard let completion = completion else {
             return
         }
-        completion("trackOrder(_:) is No longer supported. You can safely remove your usage of this method.")
+        completion(ButtonMerchantError.trackOrderDeprecationError)
     }
 }

--- a/Source/ButtonMerchantError.swift
+++ b/Source/ButtonMerchantError.swift
@@ -1,5 +1,5 @@
 //
-// String+Error.swift
+// ButtonMerchantError.swift
 //
 // Copyright © 2020 Button, Inc. All rights reserved. (https://usebutton.com)
 //
@@ -21,6 +21,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-	
-/// Allow a String to be an error for simple use cases.
-extension String: Error {}
+
+import UIKit
+
+/**
+ Button Merchant Library Errors.
+ */
+public enum ButtonMerchantError: Error {
+    
+    case trackOrderDeprecationError
+    case noEventsError
+    
+    var domain: String {
+        return "com.usebutton.merchant.error"
+    }
+    
+    var localizedDescription: String {
+        switch self {
+        case .trackOrderDeprecationError:
+            return "trackOrder(_:) is No longer supported. You can safely remove your usage of this method."
+        case .noEventsError:
+            return "No events to report"
+        }
+    }
+}
+
+extension ButtonMerchantError: Equatable {
+    
+    /// :nodoc:
+    public static func == (lhs: ButtonMerchantError, rhs: ButtonMerchantError) -> Bool {
+        return lhs.domain == rhs.domain
+            && lhs.localizedDescription == rhs.localizedDescription
+    }
+}

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -114,7 +114,7 @@ internal final class Client: ClientType {
     func reportEvents(_ events: [AppEvent], ifa: String?, _ completion: ((Error?) -> Void)?) {
         guard events.count > 0 else {
             if let completion = completion {
-                completion("No events to report")
+                completion(ButtonMerchantError.noEventsError)
             }
             return
         }

--- a/Tests/UnitTests/ButtonMerchantTests.swift
+++ b/Tests/UnitTests/ButtonMerchantTests.swift
@@ -146,8 +146,7 @@ class ButtonMerchantTests: XCTestCase {
         ButtonMerchant.trackOrder(Order(id: "test", amount: Int64(12))) { error in
             
             // Assert
-            XCTAssertEqual(error as? String,
-                           "trackOrder(_:) is No longer supported. You can safely remove your usage of this method.")
+            XCTAssertEqual(error as? ButtonMerchantError, ButtonMerchantError.trackOrderDeprecationError)
             
             expectation.fulfill()
         }

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -629,7 +629,7 @@ class ClientTests: XCTestCase {
             
             // Assert
             XCTAssertFalse(testSession.didCallDataTaskWithRequest)
-            XCTAssertEqual(error as? String, "No events to report")
+            XCTAssertEqual(error as? ButtonMerchantError, ButtonMerchantError.noEventsError)
             
             expectation.fulfill()
         }


### PR DESCRIPTION
## Overview

Conforming `String` to the `Error` protocol has implications on framework consumers. The declaration leaks outside the module and can cause compiler errors if the app also defines this conformance.

## Changes

- Replace usage of `String` errors with an internal error type.
