### PR TITLE
Add isNew property to Order.Customer

### DIFF
--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -113,9 +113,9 @@ final public class Order: NSObject, Codable {
         }
         
         /**
-         A flag indicating whether the customer is new (or not). Defaults to `false`.
+         A flag indicating whether the customer is new (or not).
          */
-        var isNew = false
+        var isNew: Bool?
 
         /**
          Initializes a customer object with the passed parameters.

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -115,7 +115,7 @@ final public class Order: NSObject, Codable {
         /**
          A flag indicating whether the customer is new (or not).
          */
-        var isNew: Bool?
+        public var isNew: Bool?
 
         /**
          Initializes a customer object with the passed parameters.

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -111,6 +111,11 @@ final public class Order: NSObject, Codable {
                 }
             }
         }
+        
+        /**
+         A flag indicating whether the customer is new (or not). Defaults to `false`.
+         */
+        var isNew = false
 
         /**
          Initializes a customer object with the passed parameters.
@@ -125,6 +130,7 @@ final public class Order: NSObject, Codable {
         enum CodingKeys: String, CodingKey {
             case id
             case email = "email_sha256"
+            case isNew = "is_new"
         }
     }
 

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -446,6 +446,7 @@ class CoreTests: XCTestCase {
         let lineItems = [Order.LineItem(id: "unique-id-1234", total: 120)]
         let customer = Order.Customer(id: "customer-id-123")
         customer.email = "test@button.com"
+        customer.isNew = true
         let order = Order(id: "order-abc", purchaseDate: date, lineItems: lineItems)
         order.customer = customer
         order.customerOrderId = "customer-order-id-123"
@@ -468,7 +469,7 @@ class CoreTests: XCTestCase {
                         "purchase_date": date.ISO8601String,
                         "customer_order_id": "customer-order-id-123",
                         "line_items": [["identifier": "unique-id-1234", "quantity": 1, "total": 120]],
-                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c"]])
+                        "customer": ["id": "customer-id-123", "email_sha256": "21f61e98ab4ae120e88ac6b5dd218ffb8cf3e481276b499a2e0adab80092899c", "is_new": 1]])
         
         testClient.reportOrderCompletion!(nil)
         

--- a/Tests/UnitTests/OrderTests.swift
+++ b/Tests/UnitTests/OrderTests.swift
@@ -134,7 +134,7 @@ class OrderTests: XCTestCase {
         // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertNil(customer.email)
-        XCTAssertFalse(customer.isNew)
+        XCTAssertNil(customer.isNew)
     }
 
     func testCustomerInitialization_allProperties_plainTextEmail() {
@@ -150,7 +150,7 @@ class OrderTests: XCTestCase {
         // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertEqual(customer.email, emailSha256)
-        XCTAssertFalse(customer.isNew)
+        XCTAssertNil(customer.isNew)
     }
 
     func testCustomerInitialization_allProperties_nonPlainTextEmail() {
@@ -165,7 +165,7 @@ class OrderTests: XCTestCase {
         // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertEqual(customer.email, emailSha256)
-        XCTAssertFalse(customer.isNew)
+        XCTAssertNil(customer.isNew)
     }
     
     func testCustomerInitialization_isNew_true() {
@@ -179,7 +179,21 @@ class OrderTests: XCTestCase {
         // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertNil(customer.email)
-        XCTAssertTrue(customer.isNew)
+        XCTAssertTrue(customer.isNew!)
+    }
+    
+    func testCustomerInitialization_isNew_false() {
+        // Arrange
+        let id = "123"
+
+        // Act
+        let customer = Order.Customer(id: id)
+        customer.isNew = false
+
+        // Assert
+        XCTAssertEqual(customer.id, id)
+        XCTAssertNil(customer.email)
+        XCTAssertFalse(customer.isNew!)
     }
 
     func testLineItemInitialization_requiredPropertiesOnly() {

--- a/Tests/UnitTests/OrderTests.swift
+++ b/Tests/UnitTests/OrderTests.swift
@@ -134,6 +134,7 @@ class OrderTests: XCTestCase {
         // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertNil(customer.email)
+        XCTAssertFalse(customer.isNew)
     }
 
     func testCustomerInitialization_allProperties_plainTextEmail() {
@@ -149,6 +150,7 @@ class OrderTests: XCTestCase {
         // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertEqual(customer.email, emailSha256)
+        XCTAssertFalse(customer.isNew)
     }
 
     func testCustomerInitialization_allProperties_nonPlainTextEmail() {
@@ -163,6 +165,21 @@ class OrderTests: XCTestCase {
         // Assert
         XCTAssertEqual(customer.id, id)
         XCTAssertEqual(customer.email, emailSha256)
+        XCTAssertFalse(customer.isNew)
+    }
+    
+    func testCustomerInitialization_isNew_true() {
+        // Arrange
+        let id = "123"
+
+        // Act
+        let customer = Order.Customer(id: id)
+        customer.isNew = true
+
+        // Assert
+        XCTAssertEqual(customer.id, id)
+        XCTAssertNil(customer.email)
+        XCTAssertTrue(customer.isNew)
     }
 
     func testLineItemInitialization_requiredPropertiesOnly() {


### PR DESCRIPTION
### Goals :dart:
* Allow the brands to identify orders that are placed by a new user.

### Example Usage
```
let customer = Order.Customer(id: customerId)
customer.email = "najm@usebutton.com"
customer.isNew = true
let order = Order(id: orderId,
                  purchaseDate: Date(),
                  lineItems: [Order.LineItem(id: itemId, total: Int64(total))])
order.customer = customer
ButtonMerchant.reportOrder(order) { error in
    guard let error = error else {
        return
    }
    // Handle error
}
```