### PR TITLE
Lock ISO8601 formatter to IS08601 calendar

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -118,7 +118,7 @@ internal final class Client: ClientType {
             }
             return
         }
-        let body = AppEventsRequestBody(ifa: ifa, events: events, currentTime: system.currentDate.eventISO8601String)
+        let body = AppEventsRequestBody(ifa: ifa, events: events, currentTime: system.currentDate.ISO8601String)
         let request = urlRequest(url: Service.appEvents.urlWith(applicationId), parameters: body.dictionaryRepresentation)
         enqueueRequest(request: request) { _, error in
             if let completion = completion {

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -138,7 +138,7 @@ final internal class Core: CoreType {
         let event = AppEvent(name: "btn:deeplink-opened",
                              value: [ "url": filteredURL.absoluteString],
                              attributionToken: incomingToken,
-                             time: system.currentDate.eventISO8601String,
+                             time: system.currentDate.ISO8601String,
                              uuid: UUID().uuidString)
         client.reportEvents([event], ifa: system.advertisingId, nil)
     }

--- a/Source/Extensions/DateExtensions.swift
+++ b/Source/Extensions/DateExtensions.swift
@@ -28,26 +28,13 @@ public extension Date {
 
     static let ISO8601Formatter = { () -> DateFormatter in
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-        return formatter
-    }()
-    
-    static let eventISO8601Formatter = { () -> DateFormatter in
-        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         return formatter
     }()
     
     var ISO8601String: String {
         return Date.ISO8601Formatter.string(from: self)
-    }
-    
-    var eventISO8601String: String {
-        return Date.eventISO8601Formatter.string(from: self)
-    }
-    
-    static func eventDateFrom(_ string: String) -> Date? {
-        return Date.eventISO8601Formatter.date(from: string)
     }
 }

--- a/Tests/UnitTests/ClientTests.swift
+++ b/Tests/UnitTests/ClientTests.swift
@@ -570,7 +570,7 @@ class ClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "report events succeeds")
         let testSession = TestURLSession()
         let testSystem = TestSystem()
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let client = Client(session: testSession,
                             userAgent: TestUserAgent(),
                             defaults: TestButtonDefaults(userDefaults: TestUserDefaults()),
@@ -588,7 +588,7 @@ class ClientTests: XCTestCase {
             XCTAssertEqual(request?.url?.absoluteString, "https://app-abc123.mobileapi.usebutton.com/v1/app/events")
             XCTAssertEqual(body.dictionaryRepresentation as NSDictionary, [
                 "ifa": "some ifa",
-                "current_time": "2019-07-25T21:30:02.844Z",
+                "current_time": "2019-07-25T21:30:02Z",
                 "events": [
                     [
                         "name": "test-event",

--- a/Tests/UnitTests/CoreTests.swift
+++ b/Tests/UnitTests/CoreTests.swift
@@ -114,7 +114,7 @@ class CoreTests: XCTestCase {
     func testTrackIncomingURL_withToken_tracksDeeplinkOpened() {
         // Arrange
         testSystem.advertisingId = "some ifa"
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let url = URL(string: "http://usebutton.com/with-token?btn_ref=faketok-abc123")!
         
         // Act
@@ -126,14 +126,14 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withoutToken_tracksDeeplinkOpened() {
         // Arrange
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let url = URL(string: "http://usebutton.com/no-token")!
 
         // Act
@@ -144,14 +144,14 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withBTNParams_tracksDeeplinkOpened() {
         // Arrange
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let url = URL(string: "http://usebutton.com/no-token/?btn_1=1&btn_2=2&btn_ref=faketok-123")!
 
         // Act
@@ -162,14 +162,14 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withFromLandingFromTrackingParams_tracksDeeplinkOpened() {
         // Arrange
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let url = URL(string: "http://usebutton.com/no-token/?from_landing=true&from_tracking=false")!
 
         // Act
@@ -180,14 +180,14 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], url.absoluteString)
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withoutButtonParams_tracksNoParams() {
         // Arrange
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let url = URL(string: "http://usebutton.com/no-token/?not_ours=param&also_not=same&utm_campaign=nope")!
 
         // Act
@@ -198,14 +198,14 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?")
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withMixedParams_tracksWithButtonParams() {
         // Arrange
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let url = URL(string: "http://usebutton.com/no-token/?theirs=param&from_landing=1&btn_test=0")!
 
         // Act
@@ -216,14 +216,14 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?from_landing=1&btn_test=0")
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }
     
     func testTrackIncomingURL_withMixedCase_tracksWithButtonParams() {
         // Arrange
-        testSystem.testCurrentDate = Date.eventDateFrom("2019-07-25T21:30:02.844Z")!
+        testSystem.testCurrentDate = Date.ISO8601Formatter.date(from: "2019-07-25T21:30:02Z")!
         let url = URL(string: "http://usebutton.com/no-token/?theirs=param&From_landing=1&Btn_test=0")!
 
         // Act
@@ -234,7 +234,7 @@ class CoreTests: XCTestCase {
         XCTAssertEqual(testClient.actualEvents?.count, 1)
         XCTAssertEqual(testClient.actualEvents?.first?.name, "btn:deeplink-opened")
         XCTAssertEqual(testClient.actualEvents?.first?.value?["url"], "http://usebutton.com/no-token/?From_landing=1&Btn_test=0")
-        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02.844Z")
+        XCTAssertEqual(testClient.actualEvents?.first?.time, "2019-07-25T21:30:02Z")
         let predicate = NSPredicate(format: "SELF MATCHES %@", "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}")
         XCTAssertTrue(predicate.evaluate(with: testClient.actualEvents?.first?.uuid))
     }

--- a/Tests/UnitTests/SystemTests.swift
+++ b/Tests/UnitTests/SystemTests.swift
@@ -62,7 +62,12 @@ class SystemTests: XCTestCase {
         XCTAssertEqualReferences(system.screen, screen)
         XCTAssertEqualReferences(system.locale as AnyObject, locale)
     }
-    
+
+    func testISO8601FormatterUsesISO8601Calendar() {
+        XCTAssertEqual(Date.ISO8601Formatter.calendar.identifier, Calendar.Identifier.iso8601)
+        XCTAssertEqual(Date.ISO8601Formatter.locale, Locale(identifier: "en_US_POSIX"))
+    }
+
     func testCurrentDateReturnsNow() {
         XCTAssertEqual(system.currentDate.ISO8601String, Date().ISO8601String)
     }

--- a/Tests/UnitTests/TestObjects/TestSystem.swift
+++ b/Tests/UnitTests/TestObjects/TestSystem.swift
@@ -61,7 +61,6 @@ final class TestSystem: SystemType {
 
         // Fix timezone to UTC for tests.
         Date.ISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
-        Date.eventISO8601Formatter.timeZone = TimeZone(identifier: "UTC")
         testCurrentDate = Date.ISO8601Formatter.date(from: "2018-01-23T12:00:00Z")!
         
         self.fileManager = fileManager


### PR DESCRIPTION
Fixes a bug where a user not using the Gregorian calendar causes incorrectly formatted purchase dates for order reporting.
